### PR TITLE
fix: run VM Updates daily with retry on lock

### DIFF
--- a/.github/workflows/vm-updates.yml
+++ b/.github/workflows/vm-updates.yml
@@ -2,8 +2,10 @@ name: VM Updates
 
 on:
   schedule:
-    # Run weekly on Monday at 2am UTC
-    - cron: '0 2 * * 1'
+    # Run daily at 2am UTC
+    # Daily schedule ensures unattended-upgrades changes are incorporated into
+    # baseline snapshots promptly (see issue #109 for rationale)
+    - cron: '0 2 * * *'
   workflow_dispatch:
 
 jobs:
@@ -66,11 +68,59 @@ jobs:
         if: steps.vm_ips.outputs.vms_exist == 'true'
         uses: actions/checkout@v4
 
-      - name: Upgrade VMs
+      - name: Upgrade VMs (with retry on lock)
         if: steps.vm_ips.outputs.vms_exist == 'true'
         env:
           HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
-        run: tests/integration/scripts/upgrade-vms.sh
+        run: |
+          # Retry logic: if VMs are locked (e.g., integration tests running),
+          # wait and retry. Integration tests take ~7 minutes, so 10-minute
+          # intervals with 5 retries (50 min max wait) should be sufficient.
+          MAX_RETRIES=5
+          RETRY_INTERVAL=600  # 10 minutes in seconds
+
+          for attempt in $(seq 1 $MAX_RETRIES); do
+            echo "=== Attempt $attempt of $MAX_RETRIES ==="
+
+            # Check if lock is currently held
+            LOCK_HOLDER=$(hcloud server describe pc1 -o json | jq -r '.labels.lock_holder // empty')
+            if [[ -n "$LOCK_HOLDER" ]]; then
+              echo "VMs are locked by: $LOCK_HOLDER"
+              if [[ $attempt -lt $MAX_RETRIES ]]; then
+                echo "Waiting ${RETRY_INTERVAL}s before retry..."
+                sleep $RETRY_INTERVAL
+                continue
+              else
+                echo "::error::VMs still locked after $MAX_RETRIES attempts. Giving up."
+                exit 1
+              fi
+            fi
+
+            # Try to run the upgrade script
+            if tests/integration/scripts/upgrade-vms.sh; then
+              echo "VM upgrade completed successfully"
+              exit 0
+            fi
+
+            # Check if failure was due to lock acquisition
+            # (script may have failed to acquire lock if someone grabbed it between check and acquire)
+            LOCK_HOLDER=$(hcloud server describe pc1 -o json | jq -r '.labels.lock_holder // empty')
+            if [[ -n "$LOCK_HOLDER" ]]; then
+              echo "Lock was acquired by $LOCK_HOLDER during upgrade attempt"
+              if [[ $attempt -lt $MAX_RETRIES ]]; then
+                echo "Waiting ${RETRY_INTERVAL}s before retry..."
+                sleep $RETRY_INTERVAL
+                continue
+              else
+                echo "::error::VMs still locked after $MAX_RETRIES attempts. Giving up."
+                exit 1
+              fi
+            fi
+
+            # Non-lock-related failure
+            echo "::error::VM upgrade failed (not due to locking)"
+            exit 1
+          done
 
       - name: VMs not available
         if: steps.vm_ips.outputs.vms_exist == 'false'

--- a/docs/ci-configuration.md
+++ b/docs/ci-configuration.md
@@ -56,7 +56,9 @@ The CI pipeline uses GitHub Actions with a tiered approach:
 | -------- | ------- | ------- |
 | `claude.yml` | @claude mentions | AI assistant |
 | `pr-requires-issue-closing.yml` | PR opened/edited/synchronized | Enforce that issues are closed via PR description/title |
-| `vm-updates.yml` | Weekly (Monday 2 AM UTC) | Upgrade test VMs |
+| `vm-updates.yml` | Daily (2 AM UTC) | Upgrade test VMs |
+
+The VM Updates workflow runs daily to incorporate security updates into the baseline snapshots within a reasonable delay.
 
 ## Branch Protection Rules (main)
 

--- a/docs/testing-infrastructure.md
+++ b/docs/testing-infrastructure.md
@@ -310,14 +310,12 @@ conftest.py (test runner - may have empty known_hosts)
 
 ### Upgrading Test VMs
 
-Test VMs should be upgraded periodically to receive security updates and package fixes. This is a maintenance operation that runs separately from integration tests to keep test runs fast and predictable.
+Test VMs are upgraded daily to receive apt updates. This is a maintenance operation that runs separately from integration tests to keep test runs fast and predictable.
 
-**When to upgrade:**
-- Weekly or monthly (recommended)
-- When security advisories affect your packages
-- If tests fail due to suspected outdated system packages
+**Why daily upgrades?**
+Ubuntu's `unattended-upgrades` runs automatically on the VMs after each boot and may install security updates (including kernel updates) before our upgrade script runs. However, they are not incorporated in the baseline snapshots until the upgrade script runs. This means that a run of the integration tests removes the updates again from the VM. Daily upgrades ensure these changes are promptly incorporated into the baseline snapshots, preventing issues where the baseline becomes stale.
 
-**How to upgrade:**
+**How to upgrade manually:**
 
 ```bash
 export HCLOUD_TOKEN=your_hcloud_token
@@ -337,8 +335,9 @@ export HCLOUD_TOKEN=your_hcloud_token
 
 **Runtime:** A few minutes (or ~1 minute if no updates available)
 
-**Automated updates:** A weekly scheduled GitHub Actions job (`vm-maintenance.yml`) automatically runs this script every Monday at 2am UTC. This job:
+**Automated updates:** A daily scheduled GitHub Actions job (`vm-updates.yml`) automatically runs this script at 2am UTC. This job:
 - Only runs if the VMs exist (non-blocking if they don't)
+- Retries up to 5 times with 10-minute intervals if VMs are locked (e.g., integration tests running)
 - Can be triggered manually via workflow_dispatch
 - Shows a warning if VMs are not available (doesn't fail the workflow)
 


### PR DESCRIPTION
## Summary
- Change VM Updates workflow from weekly to daily at 2am UTC
- Add retry logic: 5 attempts with 10-minute intervals if VMs are locked (integration tests take ~7 min)
- Update documentation in ci-configuration.md, testing-infrastructure.md, and testing-ops-guide.md

## Context
Ubuntu's `unattended-upgrades` runs automatically on VMs after boot and may install security updates (including kernel updates) before our upgrade script runs. Daily upgrades ensure these changes are promptly incorporated into the baseline snapshots.

## Test plan
- [ ] Verify workflow YAML syntax is valid
- [ ] Manual workflow trigger to test retry logic (optional)
- [ ] Review documentation updates for accuracy

Fixes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)