### PR TITLE
fix: add log for successful issue closing pattern validation in PR

### DIFF
--- a/.github/workflows/pr-requires-issue-closing.yml
+++ b/.github/workflows/pr-requires-issue-closing.yml
@@ -77,4 +77,6 @@ jobs:
                   "See docs/developer-workflow.md for details."
                 ].join("\n")
               );
+            } else {
+              core.info("All issue closing patterns found in commit messages are included in the PR title/description.");
             }


### PR DESCRIPTION
## Summary
Adds logging output when PR validation succeeds, to indicate that all issue closing patterns from commit messages are properly included in the PR title/description.

## Changes
- Added `core.info()` log message at line 81 in the workflow to confirm successful validation

## Motivation
The workflow already logs when closing patterns are found in commits and when they're missing from the PR. This change completes the logging loop by explicitly logging successful validation, improving workflow observability.

## Testing
- Existing workflow validation logic unchanged
- PR this change must include an issue reference per the enforcement rules

## Related
See `.github/workflows/pr-requires-issue-closing.yml` for the workflow that enforces issue closing keywords.