### PR TITLE
fix: skip integration status check for draft PRs

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -132,7 +132,10 @@ jobs:
     steps:
       - name: Report status
         run: |
-          if [[ "${{ needs.check-changes.outputs.should-run }}" != "true" ]]; then
+          if [[ "${{ github.event.pull_request.draft }}" == "true" ]]; then
+            echo "✓ Integration tests skipped (draft PR)"
+            exit 0
+          elif [[ "${{ needs.check-changes.outputs.should-run }}" != "true" ]]; then
             echo "✓ Integration tests skipped (no relevant changes)"
             exit 0
           elif [[ "${{ needs.integration.result }}" == "success" ]]; then


### PR DESCRIPTION
Fixes #122

## Summary
- Adds draft PR check to the integration tests status job
- Status now correctly reports "skipped" instead of failing when PR is draft

## Problem
When a draft PR had relevant file changes:
1. `check-changes` outputs `should-run=true` (files changed)
2. `integration` job is skipped (draft check in its `if` condition)
3. `status` job sees `should-run=true` but `integration.result!=success` → **fails**

## Solution
Check for draft PR first in the status job, reporting success with "Integration tests skipped (draft PR)" message.

## Test plan
- [ ] Create a draft PR with changes to `src/` and verify the status check passes
- [ ] Mark PR ready and verify integration tests run

🤖 Generated with [Claude Code](https://claude.com/claude-code)
