### PR TITLE
fix(folder_sync): force C locale on rsync so grouped byte counter no longer aborts sync

### DIFF
--- a/src/pcswitcher/jobs/folder_sync.py
+++ b/src/pcswitcher/jobs/folder_sync.py
@@ -107,16 +107,27 @@ class FolderSyncJob(SyncJob):
 
     @staticmethod
     def _parse_size_to_bytes(value: str) -> int:
-        """Convert an rsync size token (e.g. '9.53G', '317K', '512') to an integer byte count.
+        """Convert an rsync progress figure (e.g. '9.53G', '317K', '80.153.795.479') to bytes.
 
-        Multipliers: K=1024, M=1024**2, G=1024**3, T=1024**4.  A bare number (no suffix)
-        is returned as-is.  Conversion is best-effort — rsync rounds progress figures, so
-        the result is an approximation of the true cumulative byte count (WR-01).
+        Two shapes occur in --info=progress2 output:
+        - the plain byte counter, which rsync groups with the locale thousands
+          separator ('.' under nl_BE, ',' under en_US), e.g. '80.153.795.479';
+        - a human-readable figure with a K/M/G/T suffix (only when rsync runs
+          with -h), e.g. '9.53G', where the '.' is a decimal point.
+
+        rsync is forced to the C locale in `_build_rsync_cmd` so the counter is
+        ungrouped in practice, but this parser stays tolerant of grouping so a
+        stray locale-formatted figure can never abort the sync: the byte count
+        is best-effort progress metadata (WR-01), not sync-critical.
+
+        Multipliers: K=1024, M=1024**2, G=1024**3, T=1024**4.
         """
         multipliers: dict[str, int] = {"K": 1024, "M": 1024**2, "G": 1024**3, "T": 1024**4}
         if value and value[-1].upper() in multipliers:
-            return int(float(value[:-1]) * multipliers[value[-1].upper()])
-        return int(float(value))
+            # Suffixed figure carries a single decimal point; strip any comma grouping.
+            return int(float(value[:-1].replace(",", "")) * multipliers[value[-1].upper()])
+        # Plain integer counter: every '.'/',' is a thousands separator.
+        return int(value.replace(".", "").replace(",", "") or "0")
 
     def _active_folders(self) -> list[FolderEntry]:
         """Return only enabled folder entries from config."""
@@ -267,6 +278,15 @@ class FolderSyncJob(SyncJob):
         parts = [
             "sudo",
             "-E",
+            # Force the C locale so rsync's --info=progress2 byte counter is
+            # printed ungrouped.  Under a grouping locale (e.g. LC_NUMERIC=nl_BE)
+            # rsync prints "80.153.795.479"; the progress2 regex captures the
+            # whole token and float() then rejects the thousands separators,
+            # aborting the sync over a purely cosmetic figure (WR-01).  `env`
+            # runs after sudo so it sets the locale for rsync as root regardless
+            # of sudo's own env policy.
+            "env",
+            "LC_ALL=C",
             "rsync",
             "-aAXHS",
             "--numeric-ids",

--- a/tests/unit/jobs/test_folder_sync.py
+++ b/tests/unit/jobs/test_folder_sync.py
@@ -336,6 +336,11 @@ class TestBuildRsyncCmd:
         assert "--partial" in cmd
         assert "--mkpath" in cmd
 
+    def test_rsync_forced_to_c_locale(self) -> None:
+        """rsync runs under `env LC_ALL=C` so its progress2 byte counter is ungrouped."""
+        cmd = self._build()
+        assert "env LC_ALL=C rsync" in cmd
+
     def test_root_via_sudo_and_ssh_transport(self) -> None:
         """Command uses --rsync-path='sudo rsync' for remote root and an -e ssh option with -T and -l."""
         cmd = self._build()
@@ -691,6 +696,16 @@ class TestStreamRsync:
         assert FolderSyncJob._parse_size_to_bytes("1M") == 1024**2
         assert FolderSyncJob._parse_size_to_bytes("1G") == 1024**3
         assert FolderSyncJob._parse_size_to_bytes("1T") == 1024**4
+
+    async def test_parse_size_to_bytes_tolerates_thousands_separators(self) -> None:
+        """A locale-grouped byte counter parses instead of aborting the sync (WR-01).
+
+        Under a grouping locale (e.g. LC_NUMERIC=nl_BE) rsync's progress2 counter
+        is printed with thousands separators, e.g. '80.153.795.479'.  The parser
+        must strip the grouping rather than raise on float().
+        """
+        assert FolderSyncJob._parse_size_to_bytes("80.153.795.479") == 80153795479
+        assert FolderSyncJob._parse_size_to_bytes("80,153,795,479") == 80153795479
 
     async def test_created_and_hardlink_change_types_logged_at_full(self) -> None:
         """Per-file lines beginning with 'c' (created) or 'h' (hard link) are logged at FULL (IN-03)."""


### PR DESCRIPTION
## Problem

`pc-switcher sync <target>` fails with a CRITICAL during FolderSync on machines whose locale groups thousands:

```
Job folder_sync failed: could not convert string to float: '80.153.795.479'
```

rsync's `--info=progress2` prints its byte counter grouped with the locale thousands separator (`.` under `LC_NUMERIC=nl_BE`, so `80153795479` bytes → `80.153.795.479`). The progress2 regex captures the whole token and `float()` rejects it, raising `ValueError` out of `execute()`. The orchestrator turns a purely cosmetic progress figure into a fatal job failure, aborting the whole sync.

Existing tests missed it because their sample lines used a `-h`-style suffixed figure (`9.53G`), which rsync does not emit here (no `-h` flag → grouped raw integer).

## Fix

- Run rsync under `sudo -E env LC_ALL=C rsync …` so numeric output is ungrouped regardless of locale (`env` after `sudo` applies to rsync-as-root independent of sudo's env policy).
- Harden `_parse_size_to_bytes` to strip `.`/`,` thousands separators as defense-in-depth — the byte count is best-effort progress metadata (WR-01), never sync-critical.

## Tests

- `_parse_size_to_bytes` parses `80.153.795.479` and `80,153,795,479`.
- `_build_rsync_cmd` output contains `env LC_ALL=C rsync`.
- 60/60 folder_sync unit tests pass; lint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AdYt3Dx59fcuZVFiCBhdBp