### PR TITLE
ci: set up Dependabot for uv and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+# Dependabot keeps Python packages (uv) and GitHub Actions up to date.
+# Chosen over Renovate because Dependabot natively supports every ecosystem
+# this repo uses: uv (uv.lock, incl. PEP 735 [dependency-groups]) and
+# GitHub Actions. See docs: https://docs.astral.sh/uv/guides/integration/dependabot/
+version: 2
+updates:
+  # Python dependencies resolved from pyproject.toml + uv.lock.
+  # Covers both [project.dependencies] and the [dependency-groups] dev group.
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Bundle minor/patch bumps into one PR to cut noise; major bumps stay
+    # separate so breaking changes get individual review.
+    groups:
+      python-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Actions referenced by .github/workflows/*.yml.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Fixes #164

## Summary
Adds `.github/dependabot.yml` to semi-automatically update the two versioned ecosystems in this repo:

- **Python packages (uv)** — `pyproject.toml` + `uv.lock`, covering both `[project.dependencies]` and the PEP 735 `[dependency-groups]` dev group. Minor/patch bumps grouped into one weekly PR; major bumps stay separate for review.
- **GitHub Actions** — all `.github/workflows/*.yml` actions, grouped into one weekly PR.

No other versioned dependencies exist (no Docker, no other lockfiles; `install.sh` pins nothing a bot manages).

### Dependabot vs Renovate
Dependabot chosen per the decision rule "Dependabot if it supports everything; Renovate only for capabilities it lacks." Dependabot now natively supports every ecosystem here:
- uv / `uv.lock` support is GA.
- PEP 735 `[dependency-groups]` support landed in dependabot-core ([#10847](https://github.com/dependabot/dependabot-core/issues/10847), completed 2026-02-13) — needed for the `dev` group.
- GitHub Actions support is native.

No `exclude-newer` in the uv config, so no `cooldown` is required.

## Test plan
- `.github/dependabot.yml` parses as YAML and validates against the official [schemastore dependabot-2.0 schema](https://json.schemastore.org/dependabot-2.0.json).
- Verified the `pr-requires-issue-closing` workflow won't block future Dependabot PRs (it only fails when commit messages carry closing keywords, which Dependabot's don't).
- Full verification requires merge to `main` — Dependabot config only takes effect on the default branch. After merge, confirm at repo Settings → Code security, or trigger via Insights → Dependency graph → Dependabot → "Check for updates".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S2soMoS1bHMGg9MsY4LAFw