### PR TITLE
test(integration): diagnose SSH connection failures in check_vm_ready

### DIFF
--- a/tests/run-integration-tests.sh
+++ b/tests/run-integration-tests.sh
@@ -199,13 +199,25 @@ check_vm_ready() {
     local user="$2"
 
     # Try to connect and check baseline snapshot exists
-    if ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=accept-new -o BatchMode=yes \
+    ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=accept-new -o BatchMode=yes \
         "${user}@${vm_host}" \
-        "sudo btrfs subvolume show /.snapshots/baseline/@ >/dev/null 2>&1" 2>/dev/null; then
+        "sudo btrfs subvolume show /.snapshots/baseline/@ >/dev/null 2>&1" 2>/dev/null
+    local exit_code=$?
+
+    if [[ $exit_code -eq 0 ]]; then
         return 0
-    else
-        return 1
     fi
+
+    # Exit 255 = SSH transport failure (unreachable, timeout, or a rejected host
+    # key). accept-new auto-trusts a *new* key but refuses a *changed* one, so a
+    # stale known_hosts entry lands here rather than in the "not provisioned" path.
+    if [[ $exit_code -eq 255 ]]; then
+        log_error "SSH connection to ${vm_host} failed (could not run remote command)."
+        log_error "The VM may be unreachable, or its host key in ~/.ssh/known_hosts is stale."
+        log_error "Diagnose with: ssh ${user}@${vm_host} 'echo ok'"
+        log_error "If the key changed, refresh it: ssh-keygen -R ${vm_host}"
+    fi
+    return 1
 }
 
 # Check both VMs are ready


### PR DESCRIPTION
Salvages the one useful idea from the now-closed #158: when a VM readiness check fails, distinguish an SSH transport failure from a genuinely unprovisioned VM.

## Change
`check_vm_ready()` in `tests/run-integration-tests.sh` now captures the ssh exit code. On exit 255 (unreachable, timeout, or a **rejected** host key) it emits an actionable hint instead of the misleading "not provisioned yet" message.

Why 255 matters here: `StrictHostKeyChecking=accept-new` auto-trusts a *new* host key but refuses a *changed* one. A stale `known_hosts` entry (VM re-created, new IP reuse) therefore fails the connection outright — previously indistinguishable from an unprovisioned VM.

## Not carried over from #158
The rest of #158 (three-way CI/interactive/non-interactive branching, `ssh_run` strict mode) is superseded — main already pre-populates `known_hosts` via `ssh-keyscan` before this check runs.

## Verification
`bash -n` passes. No behavior change on the success path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)