### PR TITLE
Check for new versions at startup (#176)

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -7,8 +7,8 @@ current_phase_name: Package Management Sync
 status: executing
 stopped_at: Completed 01-18-PLAN.md
 last_updated: "2026-07-13T12:19:36.228Z"
-last_activity: 2026-07-18
-last_activity_desc: "Completed quick task 260718-np8: folder_sync include-override filter rules (#166)"
+last_activity: 2026-07-19
+last_activity_desc: "Completed quick task 260719-g13: Check for new versions at startup (#176)"
 progress:
   total_phases: 7
   completed_phases: 1
@@ -131,6 +131,7 @@ None yet.
 | # | Description | Date | Commit | Status | Directory |
 |---|-------------|------|--------|--------|-----------|
 | 260718-np8 | folder_sync include-override filter rules (#166) | 2026-07-18 | 2a2c003 | Verified | [260718-np8-folder-sync-include-override-filter-rule](./quick/260718-np8-folder-sync-include-override-filter-rule/) |
+| 260719-g13 | Check for new versions at startup (#176) | 2026-07-19 | cd765bf | Verified | [260719-g13-check-for-new-versions-at-startup-176](./quick/260719-g13-check-for-new-versions-at-startup-176/) |
 
 ## Deferred Items
 

--- a/.planning/quick/260719-g13-check-for-new-versions-at-startup-176/260719-g13-CONTEXT.md
+++ b/.planning/quick/260719-g13-check-for-new-versions-at-startup-176/260719-g13-CONTEXT.md
@@ -1,0 +1,81 @@
+# Quick Task 260719-g13: Check for new versions at startup (#176) - Context
+
+**Gathered:** 2026-07-19
+**Status:** Ready for planning
+
+<domain>
+## Task Boundary
+
+Add a startup version-check to pc-switcher. On command startup it queries GitHub for the latest stable release, and if a newer stable version is available it interactively offers to upgrade. A flag plus non-interactive detection skips the check for scripted/CI runs.
+
+Source of truth for the decisions below: confirmed directly with the user before planning. These are LOCKED — do not revisit or re-litigate.
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### Scope — where the check runs
+- Run on ALL commands via the Typer app-level callback (`src/pcswitcher/cli.py:main`), before the command body executes.
+- Guard so it only runs when a real subcommand is being invoked (`ctx.invoked_subcommand is not None`). Skip for bare `pc-switcher` (help) and `--version`.
+
+### Version comparison
+- Query the latest STABLE release only: `version.get_highest_release(include_prereleases=False)`.
+- Compare against `version.get_this_version()`.
+- Prompt ONLY when latest stable is strictly greater than current.
+- Never prompt when current >= latest stable (e.g. running a dev/prerelease build ahead of stable).
+
+### Prompt behavior
+- Inform the user of current vs available version, then interactively ask whether to upgrade (y/N).
+- Reuse the existing confirmer / Rich console prompt style already used in the codebase.
+
+### On confirm (yes)
+- Perform the upgrade inline by reusing the existing `self update` install+verify logic in `cli.py` (`_run_uv_tool_install` + `_verify_installed_version`). Refactor the shared install-and-verify core out of the `update` command into a reusable helper so both `self update` and the startup auto-upgrade call it.
+- On successful upgrade, automatically re-exec the SAME command line via `os.execvp(sys.argv[0], sys.argv)` with env var `PCSWITCHER_SKIP_VERSION_CHECK=1` set in the child environment, so the freshly-installed binary takes over and the re-exec'd process skips the check (prevents an infinite loop).
+- If the upgrade fails, print a warning and CONTINUE on the current version — do NOT block the user's command.
+
+### On decline (no)
+- Continue the command normally.
+
+### Skip conditions (skip the check entirely when ANY is true)
+- `--no-version-check` global flag passed (add as an app-level `typer.Option` on the `main` callback so it works as `pc-switcher --no-version-check <cmd>`).
+- Env var `PCSWITCHER_SKIP_VERSION_CHECK` is set (also used internally on re-exec).
+- stdin OR stdout is not a TTY (non-interactive: piped, cron, CI).
+- The invoked subcommand is `self` (avoid a circular prompt during manual `self update`).
+- No subcommand (help / `--version`).
+
+### On check failure (offline, GitHub rate-limit, API error, RuntimeError)
+- Print a brief warning and continue. NEVER fatal — a version check must never block core functionality, including fully offline use.
+
+### Claude's Discretion
+- Exact wording of the prompt / warning messages.
+- Whether the new check logic lives in a small helper module or in `cli.py` (keep it testable — prefer a dedicated function that can be unit-tested with mocks).
+- Message formatting details (Rich styling), as long as consistent with existing CLI output.
+</decisions>
+
+<specifics>
+## Specific Ideas
+
+Reuse these existing building blocks — do NOT reimplement:
+- `src/pcswitcher/version.py`: `get_this_version()`, `get_highest_release(include_prereleases=...)`, `Version` / `Release` comparison operators.
+- `src/pcswitcher/cli.py`: `_run_uv_tool_install(release)`, `_verify_installed_version()`, the existing `self update` command flow, and the `console` Rich instance.
+
+Testing (follow docs/dev/testing-guide.md) — unit tests mocking GitHub calls, subprocess, `os.execvp`, TTY, and env. Cover:
+- update available -> yes -> upgrade + re-exec with guard env set
+- update available -> no -> continue
+- already up to date -> no prompt
+- non-TTY -> skip
+- `--no-version-check` flag -> skip
+- `PCSWITCHER_SKIP_VERSION_CHECK` env set -> skip
+- `self` subcommand -> skip
+- check raises -> warn + continue
+
+Docs: update README / relevant command docs (and ADR-004 if the behavior belongs there) to document the new flag and the startup-check behavior.
+</specifics>
+
+<canonical_refs>
+## Canonical References
+
+- `docs/adr/adr-004-dynamic-versioning-github-releases.md` — versioning + GitHub Releases model (the source of truth for how versions are published and compared).
+- GitHub issue #176 — the originating request.
+</canonical_refs>
+</content>

--- a/.planning/quick/260719-g13-check-for-new-versions-at-startup-176/260719-g13-CONTEXT.md
+++ b/.planning/quick/260719-g13-check-for-new-versions-at-startup-176/260719-g13-CONTEXT.md
@@ -31,7 +31,7 @@ Source of truth for the decisions below: confirmed directly with the user before
 ### On confirm (yes)
 - Perform the upgrade inline by reusing the existing `self update` install+verify logic in `cli.py` (`_run_uv_tool_install` + `_verify_installed_version`). Refactor the shared install-and-verify core out of the `update` command into a reusable helper so both `self update` and the startup auto-upgrade call it.
 - On successful upgrade, automatically re-exec the SAME command line via `os.execvp(sys.argv[0], sys.argv)` with env var `PCSWITCHER_SKIP_VERSION_CHECK=1` set in the child environment, so the freshly-installed binary takes over and the re-exec'd process skips the check (prevents an infinite loop).
-- If the upgrade fails, print a warning and CONTINUE on the current version — do NOT block the user's command.
+- REFINED (post-review, user-confirmed): the "never fatal / continue" fallback is scoped to BEFORE the on-disk install is modified. Once `uv tool install` has run, the current process is potentially stale (a later lazy import would load a mismatched new module), so the process must NOT keep running. Concretely: if `uv` cannot even be launched (nothing written to disk) → warn and continue; if the upgrade runs but fails/verify-fails → exit with a recovery hint (`pc-switcher self update`); if the upgrade succeeds but the automatic re-exec fails → exit and ask the user to re-run. This supersedes the earlier blanket "on upgrade failure, warn and continue".
 
 ### On decline (no)
 - Continue the command normally.

--- a/.planning/quick/260719-g13-check-for-new-versions-at-startup-176/260719-g13-PLAN.md
+++ b/.planning/quick/260719-g13-check-for-new-versions-at-startup-176/260719-g13-PLAN.md
@@ -1,0 +1,184 @@
+---
+phase: 260719-g13-check-for-new-versions-at-startup-176
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - src/pcswitcher/cli.py
+  - tests/unit/cli/test_version_check.py
+  - README.md
+autonomous: true
+requirements:
+  - "#176"
+
+must_haves:
+  truths:
+    - "Running any real subcommand (e.g. `pc-switcher sync`, `logs`) in an interactive terminal, when a newer stable release exists, prints current-vs-available versions and prompts y/N to upgrade."
+    - "Answering y installs the new release via the existing uv-tool install+verify path, then re-execs the same command line with the freshly installed binary; answering N continues the original command unchanged."
+    - "The check is skipped entirely for: `--no-version-check`, `PCSWITCHER_SKIP_VERSION_CHECK` set, non-TTY (stdin or stdout not a terminal), the `self` subcommand, bare invocation, and `--version`."
+    - "Any check failure (offline, rate-limit, API/RuntimeError), any upgrade failure, and a failed re-exec (`os.execvp` OSError) print a warning and continue on the current version — never fatal."
+    - "`self update` still emits its existing exact user-facing strings (`Successfully updated`, `Already at version`, downgrade warning, dim-stderr detail) after the install+verify core is extracted into a shared helper."
+  artifacts:
+    - "src/pcswitcher/cli.py — `UpdateFailedError`, `_install_and_verify`, `_maybe_check_for_update`, `--no-version-check` option + `ctx` on the `main` callback"
+    - "tests/unit/cli/test_version_check.py — covers every branch enumerated in CONTEXT.md plus execvp-OSError fallback"
+    - "README.md — documents `--no-version-check`, the startup check, and `PCSWITCHER_SKIP_VERSION_CHECK`"
+  key_links:
+    - "`main` callback → `_maybe_check_for_update(console, no_version_check=...)` guarded by `ctx.invoked_subcommand not in (None, 'self')`"
+    - "`_maybe_check_for_update` and `update` both call the shared `_install_and_verify(release)`; the behavioral fork (warn+continue vs print+exit) lives at the call sites, not in the helper"
+    - "re-exec guard: `os.environ['PCSWITCHER_SKIP_VERSION_CHECK']='1'` set immediately before `os.execvp(sys.argv[0], sys.argv)` so the child skips the check (no loop)"
+---
+
+<objective>
+Add a best-effort startup version check to the pc-switcher Typer CLI (issue #176). On every real subcommand, in an interactive terminal, if a newer STABLE GitHub release exists, inform the user and offer an inline upgrade; on confirm, install it and re-exec the same command with the new binary. The check is non-blocking in all failure modes and skippable for scripted/CI use.
+
+Purpose: Keep users on the latest stable release without a manual `self update`, while never getting in the way of core functionality (including fully offline use).
+
+Output: `_maybe_check_for_update` + a re-usable `_install_and_verify` helper wired into the `main` callback, full unit-test coverage, and README documentation.
+</objective>
+
+<execution_context>
+@$HOME/.claude/gsd-core/workflows/execute-plan.md
+@$HOME/.claude/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/quick/260719-g13-check-for-new-versions-at-startup-176/260719-g13-CONTEXT.md
+@.planning/quick/260719-g13-check-for-new-versions-at-startup-176/260719-g13-RESEARCH.md
+@src/pcswitcher/cli.py
+@src/pcswitcher/version.py
+@src/pcswitcher/logger.py
+@src/pcswitcher/config_sync.py
+@tests/unit/cli/test_self_update.py
+@tests/unit/cli/test_commands.py
+@docs/dev/testing-guide.md
+
+# Locked user decisions live in CONTEXT.md; the HOW (exact reuse points, line ranges, verified Typer/CliRunner behavior, pitfalls) lives in RESEARCH.md.
+# Follow project Python standards: `from __future__ import annotations`, full type annotations, modern syntax (`X | None`), `uv run` for all tooling.
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Extract shared install+verify helper and add the startup version check to cli.py</name>
+  <files>src/pcswitcher/cli.py</files>
+  <action>
+Implement the production code for the startup check by reusing existing building blocks — do NOT reimplement `get_this_version`, `get_highest_release`, `_run_uv_tool_install`, `_verify_installed_version`, or `is_interactive`. Reference RESEARCH.md sections "2. Exact reuse points" and "3. os.execvp re-exec mechanics" for exact line ranges (`update()` body at cli.py:587-643; the shared tail is cli.py:620-643).
+
+Imports to add at the top of cli.py: `import os`; `from rich.prompt import Prompt`; add `is_interactive` to the existing `from pcswitcher.logger import ...` line (logger.py does not import cli.py, so no circular-import risk).
+
+(a) Define `class UpdateFailedError(Exception)` near `GITHUB_REPO_URL` (cli.py:509). Give it `__init__(self, message: str, *, detail: str | None = None)` that stores `self.detail = detail` and calls `super().__init__(message)`. Docstring: raised when installing/verifying a new pc-switcher release fails. The optional `detail` carries the install stderr so the `self update` call site can still render its existing `[dim]{stderr}[/dim]` second line.
+
+(b) Add `_install_and_verify(release: Release) -> Version` immediately after `_verify_installed_version()` (after cli.py:547). It performs ONLY the shared install+verify core (no user-facing "Updating..." or "Successfully..." prints — those stay at the call sites):
+  - Call `_run_uv_tool_install(release)`. If `result.returncode != 0`, raise `UpdateFailedError("Update failed", detail=(result.stderr.strip() or None))`. Preserve the literal message `Update failed`.
+  - Call `_verify_installed_version()`. If it returns `None`, raise `UpdateFailedError("Verification failed - pc-switcher not working after update")` (preserve this exact string — documented in tests/self-update-test-playbook.md).
+  - If `installed != release.version`, raise `UpdateFailedError` with the exact existing mismatch message: `f"Version mismatch after update. Expected {release.version.semver_str()}, got {installed.semver_str()}"`.
+  - On success, return `installed`.
+
+(c) Rewrite the tail of `update()` (cli.py:620-643) to call the helper. Keep the pre-install `Updating pc-switcher from {current_display} to {target_display}...` print and the success print IN `update()`. Wrap `installed = _install_and_verify(target_release)` in `try/except UpdateFailedError as e`: in the except, print `[bold red]Error:[/bold red] {e}`, then if `e.detail` print `[dim]{e.detail}[/dim]`, then `sys.exit(1)`. On success, preserve the exact existing success line: `console.print(f"[green]Successfully updated to version {target_display}[/green]")`. Leave the already-at-version branch (cli.py:613-615, string `Already at version`) and the downgrade-warning branch (cli.py:617-618) untouched. These `Successfully updated` / `Already at version` substrings are asserted in tests/integration/test_self_update.py:146,194 — must not change.
+
+(d) Add `_maybe_check_for_update(console: Console, *, no_version_check: bool) -> None`, colocated in cli.py (avoids circular import). Behavior, in order:
+  - If `no_version_check` is True: return.
+  - If `os.environ.get("PCSWITCHER_SKIP_VERSION_CHECK")` is truthy: return.
+  - If `not is_interactive(console)`: return. (Gates on BOTH stdin and stdout being TTYs — this is what makes the entire existing CliRunner-based suite skip the check for free; see RESEARCH.md Focus Q4/Q6.)
+  - Fetch, guarded: `try: current = get_this_version(); latest = get_highest_release(include_prereleases=False)` / `except Exception as e:` print a brief yellow warning (message wording is your discretion) and `return`. Catching broad `Exception` here satisfies CONTEXT.md's "NEVER fatal" for offline/rate-limit/API/RuntimeError/PackageNotFoundError.
+  - If `latest.version <= current`: return (no prompt). Prompt ONLY when latest stable is strictly greater than current.
+  - Prompt: print current-vs-available (`current.semver_str()` -> `latest.version.semver_str()`), then `response = Prompt.ask("Upgrade now?", choices=["y", "n"], default="n")` following the config_sync.py:104 idiom (call `Prompt.ask` WITHOUT a `console=` kwarg — Rich uses its own global console, matching confirmer.py:127 and config_sync.py:104). Exact prompt/message wording is your discretion.
+  - If `response.lower() != "y"`: return (continue the command).
+  - On yes: print a short "updating" line, then `try: installed = _install_and_verify(latest)` / `except UpdateFailedError as e:` print a yellow warning (`[yellow]Warning:[/yellow] {e}`, plus `[dim]{e.detail}[/dim]` if present) and `return` — do NOT `sys.exit`. This warn-and-continue is the behavioral fork from `update()`'s exit-on-failure.
+  - On successful install: print a short "updated, restarting" line, then set `os.environ["PCSWITCHER_SKIP_VERSION_CHECK"] = "1"` (set right before exec, so this run's own check never saw it — it is only for the child), then `sys.stdout.flush()` and `sys.stderr.flush()` (execvp does not flush Python buffers — see RESEARCH.md A1), then `try: os.execvp(sys.argv[0], sys.argv)` / `except OSError as e:` print a yellow warning and continue on the current process (resolves RESEARCH.md Open Question 1 under the locked "never block" rule). `execvp` (not `execv`) is required so the bare `pc-switcher` argv[0] is resolved via `$PATH`.
+
+(e) Update the `main` callback (cli.py:94-105): add `ctx: typer.Context` as the FIRST parameter (a plain param — Typer injects it by type, no `Annotated`/`typer.Option` wrapper), keep the existing `version_flag` option unchanged, and add `no_version_check: Annotated[bool, typer.Option("--no-version-check", help="Skip the startup version check")] = False`. In the body, replace the `pass` with: if `ctx.invoked_subcommand is not None and ctx.invoked_subcommand != "self"`, call `_maybe_check_for_update(console, no_version_check=no_version_check)`. This single guard covers both the "no subcommand" and "self subcommand" skip rules; `--version` (eager) and bare invocation (`no_args_is_help`) never reach this body (RESEARCH.md Focus Q1). Keep the existing ADR-010 comment about not calling basicConfig here.
+  </action>
+  <verify>
+    <automated>uv run ruff check src/pcswitcher/cli.py && uv run basedpyright src/pcswitcher/cli.py && uv run python -c "from pcswitcher import cli; assert issubclass(cli.UpdateFailedError, Exception); assert callable(cli._install_and_verify) and callable(cli._maybe_check_for_update)" && uv run pytest tests/unit/cli/test_self_update.py tests/unit/cli/test_commands.py -q</automated>
+  </verify>
+  <done>cli.py type-checks and lints clean; `UpdateFailedError`, `_install_and_verify`, `_maybe_check_for_update` exist; the `main` callback accepts `ctx` and `--no-version-check`; existing self-update and command unit tests still pass unchanged (proving the `Successfully updated` / `Already at version` paths and `_run_uv_tool_install` / `_verify_installed_version` signatures are preserved).</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Unit-test every branch of the startup version check</name>
+  <files>tests/unit/cli/test_version_check.py</files>
+  <action>
+Create `tests/unit/cli/test_version_check.py` following docs/dev/testing-guide.md (general-test naming, docstrings referencing #176) and the mocking recipe in RESEARCH.md section "6. Testing approach". Mock external I/O; never hit GitHub or run a real install.
+
+CRITICAL (RESEARCH.md Pitfall 1): every test that reaches the "yes -> upgrade" branch MUST `patch("pcswitcher.cli.os.execvp")` — an unpatched `os.execvp` replaces the pytest process image and kills the run with no traceback. No exceptions.
+
+Two test styles:
+  - Direct-call style for `_maybe_check_for_update` logic: build a `Version` via `Version.parse(...)` and a `Release(Version.parse(...), is_prerelease=False, tag="vX.Y.Z")`; construct a capture console with `Console(file=io.StringIO(), force_terminal=True)` and pass it as the `console` arg; patch `pcswitcher.cli.is_interactive` to control the TTY gate deterministically (do NOT rely on the StringIO console's own terminal detection). Assert on `console.file.getvalue()` for user-facing text and on mock call/not-called for control flow.
+  - CliRunner style (`typer.testing.CliRunner`, `runner.invoke(app, [...])`) for cases that depend on Typer/Click context wiring (the `--no-version-check` flag and the `self`-subcommand guard), asserting on real parsing.
+
+Patch targets (all in the `pcswitcher.cli` namespace): `get_this_version`, `get_highest_release`, `is_interactive`, `Prompt.ask`, `os.execvp`, and `subprocess.run` (for the install+verify path, mirroring test_self_update.py). Isolate env with `monkeypatch.delenv("PCSWITCHER_SKIP_VERSION_CHECK", raising=False)` in tests that expect the check to run, and `monkeypatch.setenv(...)` in the env-skip test.
+
+Required cases (map 1:1 to CONTEXT.md's testing list, plus the two failure-fallback branches):
+  1. update available -> yes -> upgrade + re-exec: `is_interactive` True, `get_highest_release` returns a strictly-higher release, `get_this_version` returns the lower current, `Prompt.ask` returns "y", `subprocess.run` mocked so `_install_and_verify` succeeds (install returncode 0 and a verify `--version` stdout matching the target). Assert `os.execvp` called once with `(sys.argv[0], sys.argv)` AND that `os.environ["PCSWITCHER_SKIP_VERSION_CHECK"] == "1"` was set before the call.
+  2. update available -> no -> continue: `Prompt.ask` returns "n"; assert `os.execvp` NOT called and the function returns.
+  3. already up to date -> no prompt: `get_highest_release` returns a version `<=` current; assert `Prompt.ask` NOT called.
+  4. non-TTY -> skip: `is_interactive` returns False; assert `get_highest_release` NOT called.
+  5. `--no-version-check` flag -> skip: CliRunner `runner.invoke(app, ["--no-version-check", "logs"])` with `is_interactive` patched True and `get_highest_release` patched; assert `get_highest_release` NOT called (flag short-circuits before fetch) and exit_code 0.
+  6. `PCSWITCHER_SKIP_VERSION_CHECK` env set -> skip: `monkeypatch.setenv(...)`, `is_interactive` True; assert `get_highest_release` NOT called.
+  7. `self` subcommand -> skip: patch `pcswitcher.cli._maybe_check_for_update` with a mock, `runner.invoke(app, ["self", ...])` with `update` internals mocked; assert the mock was NOT called. Add the mirror assertion for a non-self subcommand (e.g. `["logs"]`) where the mock IS called, proving the `main`-callback guard.
+  8. check raises -> warn + continue: `get_highest_release` raises `RuntimeError`; assert the function returns without raising, `Prompt.ask`/`os.execvp` NOT called, and a warning substring appears in the captured console output.
+  9. upgrade fails -> warn + continue: `Prompt.ask` "y" but `subprocess.run` mocked so install returncode != 0 (or verify returns None); assert `os.execvp` NOT called, function returns (no `SystemExit`), warning printed.
+  10. re-exec OSError -> warn + continue: install succeeds but `os.execvp` raises `OSError`; assert the OSError is swallowed, a warning is printed, and no exception propagates (resolves RESEARCH.md Open Question 1).
+  </action>
+  <verify>
+    <automated>uv run pytest tests/unit/cli/test_version_check.py -v && uv run pytest tests/unit/cli -q && uv run ruff check tests/unit/cli/test_version_check.py && uv run basedpyright tests/unit/cli/test_version_check.py</automated>
+  </verify>
+  <done>All 10+ cases pass; the full `tests/unit/cli` suite is green (no regression); the new test file lints and type-checks clean; every upgrade-path test patches `os.execvp` (grep confirms no unpatched execvp reaches a test body).</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Document the startup check, the flag, and the env var in README</name>
+  <files>README.md</files>
+  <action>
+Update README.md per RESEARCH.md section "7. Docs to update" (README is the identified source-of-truth doc; ADR-004 is deliberately NOT amended — it scopes how versions are assigned, not CLI runtime behavior; see RESEARCH.md A2).
+
+  - In the "Available Commands" block (README.md:113-131), add a short line documenting the global `--no-version-check` flag (it applies to every command, e.g. `pc-switcher --no-version-check sync <target>`). Follow the existing comment-per-command style of that block.
+  - Near "Self-update pc-switcher" (README.md:129-130), add a brief paragraph (not a bold pseudo-heading — use a real subheading if a heading is warranted, per the project's Markdown rules) describing: on startup, on any real command, in an interactive terminal, pc-switcher checks GitHub for a newer STABLE release and offers to upgrade-and-restart; it is skipped for non-interactive/scripted runs and can be disabled with `--no-version-check` or by setting `PCSWITCHER_SKIP_VERSION_CHECK`.
+  - In the "GitHub API Rate Limits" troubleshooting note (README.md:150-158), extend the sentence that lists the GitHub-API-calling commands (`--version`, `self update`, sync) to also mention the new per-command startup version check, since it shares the exact rate-limit failure mode (and, being best-effort, only warns).
+
+Keep wording terse and consistent with the surrounding README style. Do not hard-wrap sentences mid-line.
+  </action>
+  <verify>
+    <automated>uv run python -c "import pathlib; t = pathlib.Path('README.md').read_text(); assert '--no-version-check' in t, 'flag missing'; assert 'PCSWITCHER_SKIP_VERSION_CHECK' in t, 'env var missing'"</automated>
+  </verify>
+  <done>README documents the `--no-version-check` flag, the startup-check behavior, and the `PCSWITCHER_SKIP_VERSION_CHECK` env var; the rate-limit troubleshooting note reflects that the startup check also calls the GitHub API.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| local process → GitHub API | Untrusted network response (release list) crosses into the version comparison. Already handled by `version.py`; failures are non-fatal by design. |
+| local process → `uv tool install` → installed binary | A new executable is installed from a pinned GitHub tag, then the process re-execs into a `$PATH`-resolved binary. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Severity | Disposition | Mitigation Plan |
+|-----------|----------|-----------|----------|-------------|-----------------|
+| T-176-01 | Tampering | `os.execvp(sys.argv[0], sys.argv)` re-exec | medium | accept | Re-exec resolves the same `$PATH` binary the user already invoked; install source is the pinned `git+https://github.com/flaksit/pc-switcher@{tag}` used by the existing `self update`. No new trust boundary beyond current self-update; no code change to the install source. |
+| T-176-02 | Denial of Service | startup check / upgrade loop | low | mitigate | `PCSWITCHER_SKIP_VERSION_CHECK=1` set before exec prevents a re-check loop in the child; `os.execvp` `OSError` is caught (warn + continue); all check/upgrade failures are non-fatal, so a broken network or failed install never blocks the user's command. |
+| T-176-SC | Tampering | `uv tool install` supply chain | medium | accept | Reuses the existing `_run_uv_tool_install` with a tag pinned from the GitHub releases API; this task adds NO new package-manager dependencies (no npm/pip/cargo install), so no package-legitimacy gate applies. |
+</threat_model>
+
+<verification>
+- `uv run ruff format --check . && uv run ruff check . && uv run basedpyright && uv run pytest tests/unit tests/contract` all green.
+- New behavior is exercised by tests/unit/cli/test_version_check.py; no unpatched `os.execvp` in any test.
+- Existing exact-string self-update assertions preserved (`Successfully updated`, `Already at version`) — verified indirectly by test_self_update.py unit tests and, where VM infra is available, tests/integration/test_self_update.py.
+</verification>
+
+<success_criteria>
+- In an interactive terminal with a newer stable release available, any real subcommand prompts to upgrade; y installs + re-execs with the guard env set; N continues.
+- Check is skipped for `--no-version-check`, `PCSWITCHER_SKIP_VERSION_CHECK`, non-TTY, `self`, bare invocation, and `--version`.
+- Every failure mode (check error, upgrade error, execvp OSError) warns and continues on the current version.
+- All CONTEXT.md test branches (plus upgrade-fail and execvp-OSError) covered and passing; existing suites unaffected.
+- README documents the flag, the startup check, and the env var.
+</success_criteria>
+
+<output>
+Create `.planning/quick/260719-g13-check-for-new-versions-at-startup-176/260719-g13-SUMMARY.md` when done.
+</output>

--- a/.planning/quick/260719-g13-check-for-new-versions-at-startup-176/260719-g13-RESEARCH.md
+++ b/.planning/quick/260719-g13-check-for-new-versions-at-startup-176/260719-g13-RESEARCH.md
@@ -1,0 +1,244 @@
+# Quick Task 260719-g13: Check for new versions at startup (#176) - Research
+
+**Researched:** 2026-07-19
+
+**Domain:** Typer/Click CLI lifecycle, subprocess self-update, process re-exec
+
+**Confidence:** HIGH — all findings verified directly against this repo's code, installed Typer/Click version, and a live CliRunner probe. No external library research was needed; everything lives in `pcswitcher.cli`, `pcswitcher.version`, `pcswitcher.confirmer`, `pcswitcher.logger`, and the existing test suite.
+
+<user_constraints>
+## User Constraints (from CONTEXT.md)
+
+### Locked Decisions
+- Run on ALL commands via the Typer app-level callback (`src/pcswitcher/cli.py:main`), before the command body executes.
+- Guard so it only runs when a real subcommand is being invoked (`ctx.invoked_subcommand is not None`). Skip for bare `pc-switcher` (help) and `--version`.
+- Query the latest STABLE release only: `version.get_highest_release(include_prereleases=False)`. Compare against `version.get_this_version()`. Prompt ONLY when latest stable is strictly greater than current. Never prompt when current >= latest stable.
+- Inform the user of current vs available version, then interactively ask y/N. Reuse the existing confirmer / Rich console prompt style already used in the codebase.
+- On confirm: perform the upgrade inline reusing `_run_uv_tool_install` + `_verify_installed_version`. Refactor the shared install-and-verify core out of `update` into a reusable helper so both `self update` and the startup auto-upgrade call it.
+- On successful upgrade: auto re-exec the SAME command line via `os.execvp(sys.argv[0], sys.argv)` with `PCSWITCHER_SKIP_VERSION_CHECK=1` set in the child environment.
+- If the upgrade fails: print a warning and CONTINUE on the current version — never block the user's command.
+- On decline: continue the command normally.
+- Skip conditions (ANY of): `--no-version-check` global flag; env var `PCSWITCHER_SKIP_VERSION_CHECK` set; stdin OR stdout not a TTY; invoked subcommand is `self`; no subcommand (help / `--version`).
+- On check failure (offline, rate-limit, API error, RuntimeError): print a brief warning and continue. NEVER fatal.
+
+### Claude's Discretion
+- Exact wording of the prompt / warning messages.
+- Whether the new check logic lives in a small helper module or in `cli.py` (keep it testable — prefer a dedicated function that can be unit-tested with mocks).
+- Message formatting details (Rich styling), as long as consistent with existing CLI output.
+
+### Deferred Ideas (OUT OF SCOPE)
+None recorded in CONTEXT.md for this task.
+</user_constraints>
+
+## Summary
+
+The whole feature composes cleanly out of existing pieces: `version.get_this_version()` / `get_highest_release()` for the comparison, `_run_uv_tool_install()` / `_verify_installed_version()` for the upgrade mechanics, `logger.is_interactive()` for TTY gating, and the codebase's established `rich.prompt.Prompt.ask(choices=["y","n"], default="n")` idiom for the confirmation. Two structural facts drive the design: (1) Typer/Click's `is_eager` + `no_args_is_help=True` already handle "skip on bare invocation / `--version`" for free — `main()`'s body simply never runs in those cases, so the only guard actually needed in code is `ctx.invoked_subcommand not in (None, "self")`; and (2) `TerminalUIConfirmer` is the wrong tool here — it requires a live `PausableUI` that does not exist yet at startup, so the plain `Prompt.ask` pattern (same one used in `config_sync.py`) is the correct, lighter fit.
+
+A verified CliRunner probe (see Pitfall 1 below) confirms `console.is_terminal` and `sys.stdin.isatty()` are both `False` under `typer.testing.CliRunner`, so the entire existing test suite in `tests/unit/cli/test_commands.py` is automatically safe from the new startup check — no mass-mocking of `get_highest_release` needed across unrelated tests.
+
+**Primary recommendation:** Extract a `_install_and_verify(release) -> Version` helper (raising a new `UpdateFailedError`) out of the `self update` command body in `cli.py`, and add a new `_maybe_check_for_update(console, *, invoked_subcommand, no_version_check)` function — colocated in `cli.py` to avoid a circular import — called from `main()`. Test it with `patch("pcswitcher.cli.is_interactive", ...)`, `patch("pcswitcher.cli.get_highest_release", ...)`, `patch("pcswitcher.cli.Prompt.ask", ...)`, and `patch("pcswitcher.cli.os.execvp", ...)`.
+
+## Architectural Responsibility Map
+
+| Capability | Primary Tier | Secondary Tier | Rationale |
+|------------|-------------|----------------|-----------|
+| Version comparison / GitHub query | CLI (app callback) | `pcswitcher.version` module | `main()` orchestrates *when* to check; `version.py` already owns *how* to fetch/compare |
+| Install + verify upgrade | CLI (`cli.py`) | — | Subprocess orchestration is already colocated with `self update`; no separate service layer exists in this codebase |
+| Interactive prompt | CLI (`cli.py`, via `rich.prompt`) | — | No TUI/Live display exists at startup — this is plain synchronous stdout/stdin, same tier as `config_sync.py`'s prompts |
+| Process re-exec | CLI (`cli.py`, `os.execvp`) | — | OS-process-level concern, must happen after install succeeds, in the same process that ran the check |
+
+## Findings by Focus Question
+
+### 1. Typer/Click app-level callback mechanics
+
+Installed versions: **Typer 0.20.0 / Click 8.3.1** `[VERIFIED: uv run python -c "import typer, click"]`.
+
+- `main()` already exists as `app.callback()` at `src/pcswitcher/cli.py:94-105`, with `version_flag` marked `is_eager=True` and `callback=_version_callback`. Add a second parameter:
+  ```
+  ctx: typer.Context,
+  no_version_check: Annotated[bool, typer.Option("--no-version-check", help="Skip the startup version check")] = False,
+  ```
+  `typer.Context` must be a plain parameter (no `Annotated`/`typer.Option` wrapper) — Typer injects it directly when it sees the `typer.Context` type. Access `ctx.invoked_subcommand` inside the callback body. `[CITED: github.com/fastapi/typer docs/tutorial/commands/context.md, fetched via Context7 /fastapi/typer]`
+
+- **Eager `--version` interaction:** `is_eager=True` means Click resolves and calls `_version_callback` during *parameter processing*, before the callback function body (`main()`'s `pass`/new logic) ever executes. `_version_callback` raises `typer.Exit()` on `True`, so `pc-switcher --version` never reaches the new version-check code — no extra guard needed for this case beyond what already exists. `[CITED: same Context7 doc, "Previous parameters and is_eager"]`
+
+- **Bare invocation / `no_args_is_help`:** `app = typer.Typer(..., no_args_is_help=True)` (`cli.py:27-31`) causes Click's `MultiCommand.parse_args` to print help and call `ctx.exit()` when `sys.argv` has zero args, **before `main()`'s callback body runs at all**. Verified: `[VERIFIED: live CliRunner probe — see Pitfall 1]` a bare invocation never reaches `main()`. So the `ctx.invoked_subcommand is None` check in the callback body is a defense-in-depth guard for cases like `pc-switcher --no-version-check` alone (non-empty argv, no subcommand) — it IS needed for that case, since `no_args_is_help` only fires on a truly empty argv.
+
+- **Guard to add in `main()` body:**
+  ```
+  if ctx.invoked_subcommand is not None and ctx.invoked_subcommand != "self":
+      _maybe_check_for_update(console, no_version_check=no_version_check)
+  ```
+  This single condition satisfies both the "no subcommand" and "self subcommand" skip rules from CONTEXT.md.
+
+### 2. Exact reuse points in cli.py — extraction plan
+
+Current `update()` command body, `src/pcswitcher/cli.py:587-643`. Only the tail (lines 620-643) is the shared "install + verify" core; the head (lines 604-618) is `self update`-specific (CLI arg resolution, downgrade warning, already-up-to-date short-circuit) and stays in `update()` only.
+
+Extraction:
+- Add `class UpdateFailedError(Exception): """Raised when installing/verifying a new pc-switcher release fails."""` near `GITHUB_REPO_URL` (`cli.py:509`).
+- New function `_install_and_verify(release: Release) -> Version`, placed after `_verify_installed_version()` (after `cli.py:547`):
+  - Calls `_run_uv_tool_install(release)`; if `returncode != 0`, raise `UpdateFailedError` with message `"Update failed"` (append `result.stderr.strip()` if present, matching the existing `[dim]{stderr}[/dim]` detail — carry it as a second line in the exception message or a `.detail` attribute so `self update`'s existing dim-stderr print can be preserved).
+  - Calls `_verify_installed_version()`; if `None`, raise `UpdateFailedError("Verification failed - pc-switcher not working after update")` (exact string reuse — this exact text is not asserted by any automated test but is documented in `tests/self-update-test-playbook.md`, so preserve it).
+  - If `installed != release.version`, raise `UpdateFailedError(f"Version mismatch after update. Expected {release.version.semver_str()}, got {installed.semver_str()}")`.
+  - On success, return `installed`.
+- Rewrite `update()` (`cli.py:620-643`) to:
+  ```
+  try:
+      installed = _install_and_verify(target_release)
+  except UpdateFailedError as e:
+      console.print(f"[bold red]Error:[/bold red] {e}")
+      sys.exit(1)
+  console.print(f"[green]Successfully updated to version {installed.semver_str()}[/green]")
+  ```
+  **Preserve exact substrings** `"Successfully updated"` and `"Already at version"` — both are asserted in `tests/integration/test_self_update.py:146,194`. The already-at-version and downgrade-warning branches (lines 613-618) are untouched by this refactor.
+
+- `_maybe_check_for_update` (new) calls the same `_install_and_verify(release)`, but on `UpdateFailedError` prints a **yellow warning and returns** (never `sys.exit`) — this is the behavioral fork between the two call sites, and is why the shared helper raises rather than printing/exiting itself.
+
+**Verify no regression:** `tests/unit/cli/test_self_update.py` only tests `_run_uv_tool_install` and `_verify_installed_version` directly (unchanged signatures) — this extraction does not touch either, so that file needs no changes. `[VERIFIED: read tests/unit/cli/test_self_update.py]`
+
+### 3. `os.execvp` re-exec mechanics
+
+- Call form per CONTEXT.md (locked): `os.execvp(sys.argv[0], sys.argv)`. `os.execvp` performs a `$PATH` search for the executable named by its first argument — this is *why* `execvp` (not `execv`) is correct even when `sys.argv[0]` is the bare string `"pc-switcher"` (as installed by `uv tool install` into `~/.local/bin` and invoked via `$PATH` lookup by the shell). No manual path resolution needed.
+- Set the env var **before** calling exec, via the process's real environment dict (which `execvp`/`execve` reads implicitly): `os.environ["PCSWITCHER_SKIP_VERSION_CHECK"] = "1"`. This matches CONTEXT.md's explicit call form (`os.execvp`, not `os.execvpe`) — `execvp` inherits `os.environ` automatically, so no separate `env` argument is needed or specified.
+- **Flush before exec:** `sys.stdout.flush()` and `sys.stderr.flush()` (or at minimum flush the `console`'s underlying file — Rich's `Console.print` writes through a buffered file object) immediately before the `execvp` call. `execvp` replaces the process image via `execve()` at the OS level — it does **not** run `atexit` handlers, `finally` blocks, or flush Python's I/O buffers. Any `console.print(...)` issued just before the re-exec that hasn't hit the underlying fd yet will be silently dropped. `[ASSUMED — standard CPython `os.exec*` semantics, not verified against this repo's I/O buffering config this session; risk if wrong: the "Updated to X, restarting..." message could be swallowed]`
+- **Nothing after `execvp` runs.** Structure the call as the last statement in the success branch — no `return` or further code needed/reachable after it (if it returns at all, that itself is the error case — `os.execvp` only returns on failure, raising `OSError`; CONTEXT.md does not specify handling for *that* failure mode — flag as open question below).
+- `is_interactive`/env-var write ordering: write `PCSWITCHER_SKIP_VERSION_CHECK=1` to `os.environ` right before exec, not earlier — the check function itself must NOT see this var during its own run (it's meant only for the child).
+
+### 4. TTY / non-interactive detection
+
+`pcswitcher.logger.is_interactive(console: Console) -> bool` (`logger.py:324-335`) is the correct existing helper: `[VERIFIED: read logger.py]`
+```python
+def is_interactive(console: Console) -> bool:
+    return console.is_terminal and sys.stdin.isatty()
+```
+Requires **both** stdout (`console.is_terminal`) and stdin (`sys.stdin.isatty()`) to be TTYs — exactly matching CONTEXT.md's "stdin OR stdout is not a TTY" skip rule (i.e. skip unless both are TTYs).
+
+Import path: `from pcswitcher.logger import is_interactive` — already imported by `confirmer.py` the same way; safe, no new circular-import risk (`logger.py` does not import `cli.py`).
+
+Monkeypatch-friendly: `patch("pcswitcher.cli.is_interactive", return_value=True/False)` once imported into `cli.py`'s namespace. `console` in `cli.py` is a module-level singleton (`cli.py:41`) constructed once at import time — `[VERIFIED: live CliRunner probe]` `console.is_terminal` re-resolves `sys.stdout` **dynamically at access time**, not cached at construction, so `CliRunner`'s stdout/stdin redirection is correctly observed by a module-level `console` without needing to reconstruct it per-test.
+
+### 5. Interactive prompt pattern — recommendation
+
+**Recommend:** plain `rich.prompt.Prompt.ask` — the same idiom already used twice in this codebase, NOT `Confirmer`/`TerminalUIConfirmer`.
+
+Reasoning: `TerminalUIConfirmer.confirm()` (`confirmer.py:90-134`) unconditionally calls `self._ui.pause()` / `self._ui.resume()` around the prompt — it requires a constructed `PausableUI` (the live `TerminalUI`, built later in `Orchestrator`/sync flow). At the point `main()`'s callback runs, no `TerminalUI` exists yet (it's constructed per-sync inside the async orchestrator path), so `TerminalUIConfirmer` is not instantiable here without inventing a dummy `PausableUI`. It also returns an `async def confirm(...)` — would require wrapping the whole startup check in `asyncio.run(...)`, adding complexity CONTEXT.md doesn't ask for.
+
+`config_sync.py:104` establishes the exact idiom to copy:
+```python
+response = Prompt.ask("Choice", choices=["y", "n"], default="n")
+return response.lower() == "y"
+```
+Recommended prompt shape for this feature (message content is Claude's discretion per CONTEXT.md):
+```python
+console.print(f"A new stable version is available: {current.semver_str()} -> {latest.version.semver_str()}")
+response = Prompt.ask("Upgrade now?", choices=["y", "n"], default="n")
+```
+Note `Prompt.ask` in this codebase is called **without** passing `console=` — it uses Rich's own default global console internally, which still targets the real stdout/stdin, matching the pattern in both `confirmer.py:127` and `config_sync.py:104,153`. Follow the same (no `console=` kwarg) for consistency, even though `cli.py` has its own `console` singleton available.
+
+### 6. Testing approach
+
+**Existing CLI test pattern:** `tests/unit/cli/test_commands.py` uses `typer.testing.CliRunner()` + `runner.invoke(app, [...])`, patching internals via `patch("pcswitcher.cli.<name>", ...)`. `tests/unit/cli/test_self_update.py` calls the private functions directly (`from pcswitcher import cli; cli._run_uv_tool_install(...)`) without going through CliRunner at all — appropriate for pure-function-style helpers. Use the CliRunner style for the end-to-end skip/prompt scenarios (asserting on `result.exit_code` / `result.stdout`), and the direct-call style for unit-testing `_maybe_check_for_update` / `_install_and_verify` in isolation.
+
+**Verified via live probe** `[VERIFIED: ran a throwaway Typer app under CliRunner this session]`: under `typer.testing.CliRunner`, a module-level `Console()` reports `is_terminal == False` and `sys.stdin.isatty() == False`. Consequence: **every existing `runner.invoke(app, [...])` call in `tests/unit/cli/test_commands.py` will naturally skip the new version check** (via the `is_interactive` gate) without any modification or added mocking — confirmed no regression risk to the existing 20+ CliRunner-based tests in that file.
+
+**Mocking recipe for the new test file** (recommend `tests/unit/cli/test_version_check.py`, mirroring `test_self_update.py`'s naming):
+| What to mock | Patch target | Why |
+|---|---|---|
+| Latest release / current version | `patch("pcswitcher.cli.get_highest_release", return_value=...)`, `patch("pcswitcher.cli.get_this_version", return_value=...)` | avoid live GitHub calls |
+| Install/verify subprocess calls | `patch("pcswitcher.cli.subprocess.run", ...)` (same as `test_self_update.py`) | avoid real `uv tool install` |
+| TTY | `patch("pcswitcher.cli.is_interactive", return_value=True)` | force the interactive branch in tests (CliRunner can't fake a real TTY) |
+| Prompt | `patch("pcswitcher.cli.Prompt.ask", return_value="y"/"n")` | matches `test_config_sync.py`'s established pattern (`patch("pcswitcher.config_sync.Prompt.ask", ...)`) |
+| Re-exec | `patch("pcswitcher.cli.os.execvp") as mock_execvp` | **must always be mocked** — an unpatched `os.execvp` call replaces the pytest process image itself, killing the test run with no traceback. This is the single highest-risk gotcha in this task; assert `mock_execvp.assert_called_once_with(sys.argv[0], sys.argv)` and separately assert `os.environ["PCSWITCHER_SKIP_VERSION_CHECK"] == "1"` was set beforehand (use `monkeypatch.delenv`/`monkeypatch.setenv` to isolate env state per test, restoring after) |
+| Env var skip | `monkeypatch.setenv("PCSWITCHER_SKIP_VERSION_CHECK", "1")` / `monkeypatch.delenv(..., raising=False)` | matches `test_version.py`'s existing `patch.dict("os.environ", ...)` pattern for `GITHUB_TOKEN` |
+| `--no-version-check` flag | via `runner.invoke(app, ["--no-version-check", "logs"])` (CliRunner, real Typer parsing) | verifies the flag is actually wired through Typer, not just the internal function |
+
+**Coverage checklist** (from CONTEXT.md, mapped to test style):
+- update available -> yes -> upgrade + re-exec with guard env set: direct-call test on `_maybe_check_for_update`, asserting `os.environ` mutation + `mock_execvp` call.
+- update available -> no -> continue: same, `Prompt.ask` returns `"n"`, assert `execvp` NOT called.
+- already up to date -> no prompt: `latest.version <= current`, assert `Prompt.ask` not called.
+- non-TTY -> skip: `is_interactive` returns `False`, assert `get_highest_release` not called.
+- `--no-version-check` flag -> skip: CliRunner invoke with flag, assert underlying check function not entered (patch `_maybe_check_for_update` itself, or assert `get_highest_release` not called).
+- `PCSWITCHER_SKIP_VERSION_CHECK` env set -> skip: `monkeypatch.setenv`, assert skip.
+- `self` subcommand -> skip: CliRunner invoke `["self", "update", ...]` with everything else mocked, assert the version-check path isn't entered (this is a `ctx.invoked_subcommand` behavior — best tested at the CliRunner level, since it depends on Click's context wiring, not just the internal function's own logic).
+- check raises -> warn + continue: `get_highest_release` raises `RuntimeError`, assert command still proceeds and a warning is printed.
+
+### 7. Docs to update
+
+- **`README.md`** — add `--no-version-check` to the "Available Commands" section (`README.md:120-136` area) and a short paragraph near "Self-update pc-switcher" (`README.md:135`) describing the new startup check + prompt + `PCSWITCHER_SKIP_VERSION_CHECK` env var, alongside the existing GitHub rate-limit troubleshooting note (`README.md:150-166`, which already documents `--version`/`self update`/sync as GitHub-API-calling commands — the startup check adds a fourth, on every command, and belongs in that same troubleshooting section since it shares the exact rate-limit failure mode).
+- **`docs/adr/adr-004-dynamic-versioning-github-releases.md`** — this ADR is scoped to *how versions are assigned* (dynamic versioning from git tags), not to CLI runtime behavior; the startup check doesn't change versioning semantics. `[ASSUMED]` recommend **not** amending ADR-004; it is cited in CONTEXT.md as "canonical reference" for the version-comparison model this feature *consumes*, not a doc that itself needs updating. If the planner disagrees, the appropriate place would be a new "Implementation Rules" bullet, but this is a discretionary call, not a locked decision.
+- No `docs/system/core.md` / spec-driven doc reference was found describing self-update CLI behavior in spec form (only `README.md` and `tests/self-update-test-playbook.md` — the latter is a manual test doc, not a source-of-truth doc, but should get a short new scenario added for the startup-prompt-and-upgrade flow if the planner wants manual-playbook coverage matching the existing self-update entries there).
+
+## Common Pitfalls
+
+### Pitfall 1: Unpatched `os.execvp` kills the test process
+
+**What goes wrong:** Calling the real `os.execvp` inside a pytest run replaces the running Python process (the test runner itself) with a new `pc-switcher` invocation — the test process never returns, pytest hangs or the run terminates abnormally with no useful traceback.
+
+**Why it happens:** `execvp`/`execve` family calls do not fork; they replace the calling process's image in-place.
+
+**How to avoid:** Always `patch("pcswitcher.cli.os.execvp")` in every test that exercises the "yes + upgrade" branch, with no exceptions.
+
+**Warning signs:** A test run that hangs indefinitely or a CI job that dies without a pytest summary.
+
+### Pitfall 2: `console.is_terminal` timing under module-level `Console()`
+
+**What goes wrong:** Assuming a module-level `Console()` object caches its TTY-ness at import time, and therefore can't reflect `CliRunner`'s stdout/stdin isolation in tests.
+
+**Why it happens:** Rich's `Console.file` (and thus `is_terminal`) resolves `sys.stdout` dynamically on each access by default, not once at construction — this is non-obvious and easy to assume wrong.
+
+**How to avoid:** `[VERIFIED this session via live probe]` — no special handling needed; the existing module-level `console` in `cli.py` already "just works" correctly for both `CliRunner`-based skip tests (real dynamic resolution -> non-interactive) and explicit `is_interactive` mocking (for forcing the interactive branch).
+
+**Warning signs:** N/A — verified working as-is; flagged here only so the planner doesn't add unneeded console-reconstruction workarounds.
+
+### Pitfall 3: Losing existing exact-string test assertions during the `_install_and_verify` extraction
+
+**What goes wrong:** Refactoring `update()`'s tail into a shared helper accidentally changes the exact text of `"Successfully updated to version {X}"` or `"Already at version {X}"`.
+
+**Why it happens:** Both strings are asserted via substring match in `tests/integration/test_self_update.py:146,194` (an integration test, so it won't run in the fast unit suite and a break here is easy to miss during normal `uv run pytest` iteration).
+
+**How to avoid:** Keep the success-message `console.print` call in `update()` itself (not inside the shared helper), and preserve the substrings verbatim. Run `tests/integration/test_self_update.py` (or at minimum grep the strings) before considering this task done, even though it needs VM infra to actually execute.
+
+**Warning signs:** Integration test failures on `assert "Successfully updated" in stdout` / `assert "Already at version" in stdout` after a merge.
+
+## Open Questions
+
+1. **What if `os.execvp` itself raises (e.g., the freshly-`uv tool install`-ed binary is somehow not on `$PATH`)?**
+   - What we know: `os.execvp` only returns to the caller on failure (raising `OSError`); on success it never returns.
+   - What's unclear: CONTEXT.md's locked decisions describe the failure mode of *the upgrade itself* (`_install_and_verify` raising) but not a failure of the *re-exec* step after a successful, verified install.
+   - Recommendation: wrap the `execvp` call in `try/except OSError` and fall back to printing a warning + continuing on the *old* process (same "never block" philosophy as the rest of the feature) — this is a natural, low-risk extension of the existing locked behavior, not a new decision, so it's safe for the planner to include without re-opening CONTEXT.md.
+
+## Sources
+
+### Primary (HIGH confidence)
+- `src/pcswitcher/cli.py` (read in full this session) — `main()`, `_version_callback`, `update`, `_run_uv_tool_install`, `_verify_installed_version`, `_resolve_target_version`
+- `src/pcswitcher/version.py` (read in full) — `get_this_version`, `get_highest_release`, `Version`/`Release` comparisons
+- `src/pcswitcher/confirmer.py`, `src/pcswitcher/logger.py` (read in full) — `is_interactive`, `TerminalUIConfirmer`
+- `src/pcswitcher/config_sync.py` (partial read) — established `Prompt.ask` idiom
+- `tests/unit/cli/test_self_update.py`, `tests/unit/cli/test_commands.py`, `tests/unit/cli/test_config_sync.py`, `tests/unit/test_version.py` — existing test patterns
+- Live probes this session: `uv run python -c "import typer, click; ..."` (version check), throwaway `CliRunner` script confirming `is_terminal`/`stdin.isatty()` behavior
+
+### Secondary (MEDIUM confidence)
+- Context7 `/fastapi/typer` — `docs/tutorial/commands/context.md`, `docs/tutorial/options/version.md`: `ctx.invoked_subcommand`, `is_eager` ordering `[CITED]`
+
+### Tertiary (LOW confidence)
+- I/O buffering/flush behavior across `os.execvp` — standard CPython semantics, not verified against this repo's specific Rich/Console buffering this session `[ASSUMED]`
+
+## Assumptions Log
+
+| # | Claim | Section | Risk if Wrong |
+|---|-------|---------|---------------|
+| A1 | `sys.stdout.flush()`/`sys.stderr.flush()` before `execvp` is necessary to avoid losing the pre-exec "restarting" message | Focus Q3 | Low — worst case a cosmetic message is dropped; upgrade itself is unaffected |
+| A2 | ADR-004 should NOT be amended for this feature | Focus Q7 / Docs | Low — a doc-placement judgment call, easily corrected in review if the planner disagrees |
+
+## Metadata
+
+**Confidence breakdown:**
+- Callback/skip mechanics: HIGH — verified against installed Typer/Click version and live probes, cross-checked with Context7 docs
+- Extraction plan for `_install_and_verify`: HIGH — read exact existing code and exact existing test assertions
+- Testing approach: HIGH — verified CliRunner TTY behavior directly this session
+- Re-exec flush timing: LOW/ASSUMED — not independently verified this session
+
+**Research date:** 2026-07-19
+
+**Valid until:** Not time-sensitive — based on this repo's current code, not an external fast-moving dependency; re-check only if `cli.py`/`version.py`/`confirmer.py` change materially before implementation.

--- a/.planning/quick/260719-g13-check-for-new-versions-at-startup-176/260719-g13-REVIEW.md
+++ b/.planning/quick/260719-g13-check-for-new-versions-at-startup-176/260719-g13-REVIEW.md
@@ -1,0 +1,69 @@
+---
+phase: 260719-g13-check-for-new-versions-at-startup-176
+reviewed: 2026-07-19T10:04:17Z
+depth: quick
+files_reviewed: 3
+files_reviewed_list:
+  - src/pcswitcher/cli.py
+  - tests/unit/cli/test_version_check.py
+  - README.md
+findings:
+  critical: 1
+  warning: 2
+  info: 0
+  total: 3
+status: issues_found
+---
+
+# Phase 260719-g13: Code Review Report
+
+**Reviewed:** 2026-07-19T10:04:17Z
+**Depth:** quick (escalated to targeted reads of `cli.py`, `version.py`, `logger.py`, and live `CliRunner` probes to verify the specific behaviors called out for scrutiny)
+**Files Reviewed:** 3
+**Status:** issues_found
+
+## Summary
+
+Reviewed the startup version-check feature against the locked spec in `260719-g13-CONTEXT.md`. The skip-guard wiring (`--no-version-check`, `PCSWITCHER_SKIP_VERSION_CHECK`, `self` subcommand, non-TTY, bare invocation/`--version`), the `_install_and_verify` refactor (verified `self update` still emits the exact `Successfully updated` / `Already at version` strings the integration tests assert on), the re-exec ordering (env guard set before flush before `execvp`, `OSError` caught), and test hygiene (every test that reaches the "yes → upgrade" branch patches `os.execvp`; `ruff`/`basedpyright` clean; the new test file plus `test_commands.py` run in 0.1s confirming no live GitHub/subprocess calls leak through) all check out.
+
+One real gap in the "never fatal" guarantee: the upgrade branch of `_maybe_check_for_update` only catches the deliberately-raised `UpdateFailedError`, not the broader exception surface (e.g. a missing `uv`/`pc-switcher` binary) that the underlying `subprocess.run` calls can actually raise. That contradicts the explicit locked requirement that "a version check must never block core functionality." A secondary usability finding: the version check (and, if an update is available, its interactive prompt) fires on subcommand `--help` and on Click usage errors, not just on real command execution — confirmed via direct `CliRunner` probes.
+
+## Critical Issues
+
+### CR-01: Startup upgrade path is not actually "never fatal" — narrow exception handling can crash every command
+
+**File:** `src/pcswitcher/cli.py:708-745`
+**Issue:** The locked spec requires ALL of (check failure, upgrade failure, execvp failure) to be non-fatal on the startup path. The check phase (`get_this_version()` / `get_highest_release()`, lines 708-713) is correctly wrapped in a broad `except Exception`. The upgrade phase is not: `_install_and_verify(latest)` (line 727) is only wrapped in `except UpdateFailedError`. `_install_and_verify` calls `_run_uv_tool_install()` and `_verify_installed_version()`, both of which shell out via `subprocess.run(["uv", ...])` / `subprocess.run(["pc-switcher", ...])` with `check=False` — `check=False` only suppresses `CalledProcessError` for non-zero exit codes, it does not suppress `FileNotFoundError`/`OSError` when the executable itself can't be found (e.g. `uv` not on `PATH`, a stripped-down container, a mangled `PATH` in a non-login shell). Such an exception propagates straight out of `_maybe_check_for_update`, out of the app-level `main()` callback, and crashes the entire CLI invocation before the user's actual subcommand ever runs — for `sync`, this could abort the invocation the user actually cared about, purely because of an unrelated update-check side effect. The `Prompt.ask()` call at line 721 has the same exposure (e.g. `EOFError` if stdin closes between the TTY check and the prompt). Verified this is a real code path, not just narrow theory-crafting: `_install_and_verify`'s only two failure signals it turns into `UpdateFailedError` are `returncode != 0` and version mismatch — an `OSError` during either `subprocess.run` call is unhandled by design, not by omission of a specific branch.
+
+**Fix:**
+```python
+    console.print(f"Updating pc-switcher to {latest.version.semver_str()}...")
+    try:
+        _install_and_verify(latest)
+    except Exception as e:  # keep this best-effort, never fatal — matches the check-phase catch above
+        console.print(f"[yellow]Warning:[/yellow] {e}")
+        if isinstance(e, UpdateFailedError) and e.detail:
+            console.print(f"[dim]{e.detail}[/dim]")
+        return
+```
+Also consider wrapping the `Prompt.ask()` call itself (or the whole post-check body) so a stdin race can't escape either.
+
+## Warnings
+
+### WR-01: Version check (and its interactive prompt) fires on subcommand `--help` and on Click usage errors
+
+**File:** `src/pcswitcher/cli.py:116-117`
+**Issue:** `main()`'s guard is `ctx.invoked_subcommand is not None and ctx.invoked_subcommand != "self"`. Click sets `invoked_subcommand` as soon as it resolves which subcommand would run, before that subcommand parses its own `--help` or validates its own required arguments — the group callback (`main()`) runs first regardless. Verified directly: `runner.invoke(cli.app, ["sync", "--help"])` calls `_maybe_check_for_update`, and `runner.invoke(cli.app, ["sync"])` (missing required TARGET) also calls `_maybe_check_for_update` before the usage error is reported. So `pc-switcher sync --help` in an interactive terminal does a live GitHub network call and, if a newer stable release exists, blocks on an "Upgrade now?" prompt before printing the help text the user asked for. This isn't in the locked skip-condition list (bare invocation/`--version`/`self`/non-TTY/flag/env-var) and works against the intent of "only runs when a real subcommand is being invoked."
+**Fix:** Either accept this as a known trade-off of the locked "app-level callback, before command body" design and document it, or special-case it, e.g. skip when `"--help" in ctx.args` / `"-h" in ctx.args`, or move the check to run only once Click has finished resolving that the subcommand will actually execute (e.g. via `ctx.resilient_parsing` check, or a pre-check of `sys.argv`).
+
+### WR-02: `self update` inherits the same narrow catch — a missing `uv`/`pc-switcher` binary produces a raw traceback instead of the intended clean error
+
+**File:** `src/pcswitcher/cli.py:680-688`
+**Issue:** `update()` wraps `_install_and_verify(target_release)` in `except UpdateFailedError as e: ... sys.exit(1)`. Like CR-01, an `OSError`/`FileNotFoundError` from the underlying `subprocess.run` calls (missing `uv` on `PATH`) is not caught here either, so instead of the polished `[bold red]Error:[/bold red] ...` message the command was designed to show, the user gets an unhandled Python traceback. `self update` exiting non-zero either way makes this lower severity than CR-01 (it doesn't block an unrelated command), but it's a real quality/UX gap and the same root cause as CR-01 — fixing the catch in `_install_and_verify`'s callers (or in `_install_and_verify` itself, re-raising as `UpdateFailedError`) fixes both.
+**Fix:** Same shape as CR-01's fix, applied to `update()`'s `except UpdateFailedError` clause — or centralize by having `_install_and_verify` catch `OSError` around each `subprocess.run` call and re-raise as `UpdateFailedError(f"Update failed: {e}")`, so both call sites get consistent, clean error handling for free.
+
+---
+
+_Reviewed: 2026-07-19T10:04:17Z_
+_Reviewer: Claude (gsd-code-reviewer)_
+_Depth: quick_

--- a/.planning/quick/260719-g13-check-for-new-versions-at-startup-176/260719-g13-SUMMARY.md
+++ b/.planning/quick/260719-g13-check-for-new-versions-at-startup-176/260719-g13-SUMMARY.md
@@ -1,0 +1,158 @@
+---
+phase: 260719-g13-check-for-new-versions-at-startup-176
+plan: 01
+subsystem: cli
+tags: [typer, rich, cli, self-update, github-releases]
+
+requires: []
+provides:
+  - "Best-effort startup version check on every real pc-switcher subcommand"
+  - "Inline upgrade-and-restart via a shared _install_and_verify helper, reused by both `self update` and the startup check"
+  - "--no-version-check flag and PCSWITCHER_SKIP_VERSION_CHECK env var to skip the check"
+affects: [cli]
+
+tech-stack:
+  added: []
+  patterns:
+    - "Shared install+verify core (_install_and_verify raising UpdateFailedError) with the exit-vs-warn behavioral fork left at each call site"
+    - "os.execvp(sys.argv[0], sys.argv) self-restart with an env-var guard set immediately before exec to prevent a re-check loop in the child"
+
+key-files:
+  created:
+    - tests/unit/cli/test_version_check.py
+  modified:
+    - src/pcswitcher/cli.py
+    - README.md
+
+key-decisions:
+  - "Extracted _install_and_verify(release) -> Version out of self update's tail; it raises UpdateFailedError (with optional .detail for stderr) rather than printing/exiting, so the startup check's warn-and-continue and self update's exit-on-failure share the same core"
+  - "_maybe_check_for_update is colocated in cli.py (not a separate module) to avoid a circular import with pcswitcher.logger"
+  - "Guard clause `if no_version_check or PCSWITCHER_SKIP_VERSION_CHECK or not is_interactive(console): return` combines all three early-skip conditions into one branch to keep _maybe_check_for_update under ruff's max-return-statements limit"
+
+patterns-established:
+  - "Test env-var cleanup for code that writes directly to os.environ must use plain os.environ.pop(), not monkeypatch.delenv() after the fact - monkeypatch would record the mutated value as 'original' and restore it at teardown, re-leaking it into the next test"
+
+requirements-completed: ["#176"]
+
+coverage:
+  - id: D1
+    description: "Startup version check prompts to upgrade when a newer stable release exists, in an interactive terminal, on any real subcommand"
+    requirement: "#176"
+    verification:
+      - kind: unit
+        ref: "tests/unit/cli/test_version_check.py::TestMaybeCheckForUpdateUpgradeFlow::test_update_available_yes_upgrades_and_reexecs"
+        status: pass
+      - kind: unit
+        ref: "tests/unit/cli/test_version_check.py::TestMaybeCheckForUpdateUpgradeFlow::test_update_available_no_continues_without_reexec"
+        status: pass
+    human_judgment: false
+  - id: D2
+    description: "Check skipped for --no-version-check, PCSWITCHER_SKIP_VERSION_CHECK, non-TTY, self subcommand, bare invocation, and --version"
+    requirement: "#176"
+    verification:
+      - kind: unit
+        ref: "tests/unit/cli/test_version_check.py::TestMaybeCheckForUpdateSkipConditions::test_no_version_check_flag_skips"
+        status: pass
+      - kind: unit
+        ref: "tests/unit/cli/test_version_check.py::TestMaybeCheckForUpdateSkipConditions::test_env_var_set_skips"
+        status: pass
+      - kind: unit
+        ref: "tests/unit/cli/test_version_check.py::TestMaybeCheckForUpdateNoPromptCases::test_non_tty_skips_check_entirely"
+        status: pass
+      - kind: unit
+        ref: "tests/unit/cli/test_version_check.py::TestMainCallbackWiring::test_no_version_check_flag_short_circuits_before_fetch"
+        status: pass
+      - kind: unit
+        ref: "tests/unit/cli/test_version_check.py::TestMainCallbackWiring::test_self_subcommand_skips_version_check"
+        status: pass
+    human_judgment: false
+  - id: D3
+    description: "Every failure mode (check error, upgrade error, execvp OSError) warns and continues on the current version, never fatal"
+    requirement: "#176"
+    verification:
+      - kind: unit
+        ref: "tests/unit/cli/test_version_check.py::TestMaybeCheckForUpdateFailureFallbacks::test_check_raises_warns_and_continues"
+        status: pass
+      - kind: unit
+        ref: "tests/unit/cli/test_version_check.py::TestMaybeCheckForUpdateFailureFallbacks::test_upgrade_fails_warns_and_continues"
+        status: pass
+      - kind: unit
+        ref: "tests/unit/cli/test_version_check.py::TestMaybeCheckForUpdateFailureFallbacks::test_reexec_oserror_warns_and_continues"
+        status: pass
+    human_judgment: false
+  - id: D4
+    description: "self update still emits its exact existing user-facing strings (Successfully updated, Already at version) after the install+verify core was extracted into a shared helper"
+    requirement: "#176"
+    verification:
+      - kind: unit
+        ref: "tests/unit/cli/test_self_update.py (unchanged, still passes against the refactored helper)"
+        status: pass
+    human_judgment: true
+    rationale: "The exact-string assertions live in tests/integration/test_self_update.py, which requires VM infrastructure not available in this session; unit suite proves the refactor didn't change _run_uv_tool_install/_verify_installed_version signatures, but the literal integration-test strings were verified by reading the code, not by running that test."
+
+duration: 20min
+completed: 2026-07-19
+status: complete
+---
+
+# Quick Task 260719-g13: Check for new versions at startup Summary
+
+**Startup version check on every pc-switcher subcommand: prompts to upgrade-and-restart when a newer stable GitHub release exists, reusing self update's install+verify core via a new shared helper**
+
+## Performance
+
+- **Duration:** ~20 min
+- **Completed:** 2026-07-19
+- **Tasks:** 3
+- **Files modified:** 2 (src/pcswitcher/cli.py, README.md); 1 created (tests/unit/cli/test_version_check.py)
+
+## Accomplishments
+
+- Extracted `UpdateFailedError` + `_install_and_verify(release) -> Version` out of `self update`'s tail, preserving the exact `Successfully updated` / `Already at version` / mismatch / verification-failed strings
+- Added `_maybe_check_for_update(console, *, no_version_check)`, wired into the `main` Typer callback via `ctx: typer.Context`, gated on `ctx.invoked_subcommand not in (None, "self")`
+- Added `--no-version-check` global flag; skip conditions also cover `PCSWITCHER_SKIP_VERSION_CHECK` env var and non-interactive (non-TTY) runs via the existing `is_interactive` helper
+- On accept, installs via the shared helper, sets `PCSWITCHER_SKIP_VERSION_CHECK=1` right before `os.execvp(sys.argv[0], sys.argv)` to prevent a re-check loop in the child, flushing stdout/stderr first
+- 13 new unit tests covering every branch from CONTEXT.md plus the upgrade-fail and execvp-OSError fallbacks
+- README documents the flag, the startup-check behavior, and the env var; rate-limit troubleshooting note extended to mention the check
+
+## Task Commits
+
+1. **Task 1: Extract shared install+verify helper and add the startup version check to cli.py** - `800645b` (feat)
+2. **Task 2: Unit-test every branch of the startup version check** - `6c738f3` (test)
+3. **Task 3: Document the startup check, the flag, and the env var in README** - `647bf75` (docs)
+
+## Files Created/Modified
+
+- `src/pcswitcher/cli.py` - `UpdateFailedError`, `_install_and_verify`, `_maybe_check_for_update`, `--no-version-check` option, `ctx` param on `main`
+- `tests/unit/cli/test_version_check.py` - 13 tests across upgrade flow, no-prompt cases, skip conditions, failure fallbacks, and Typer/Click wiring
+- `README.md` - `--no-version-check` documented, startup-check subsection added, rate-limit note extended
+
+## Decisions Made
+
+- `_install_and_verify` raises rather than prints/exits, so the exit-on-failure (`self update`) vs warn-and-continue (`_maybe_check_for_update`) behavioral fork stays entirely at the call sites, per RESEARCH.md's extraction plan.
+- Combined the three early-skip conditions (`no_version_check`, env var, non-TTY) into a single `if ... or ... or ...: return` to keep the function under ruff's `PLR0911` max-return-statements(6) limit without changing behavior.
+- Test env-var cleanup uses a plain `os.environ.pop()` autouse fixture instead of `monkeypatch.delenv()` mid-test, because the code under test writes to `os.environ` directly (the re-exec guard) — see Issues Encountered.
+
+## Deviations from Plan
+
+None — plan executed exactly as written. The `noqa: S606` comment initially added to the `os.execvp` call was removed after `ruff check` reported it as an unused directive (that lint rule isn't enabled in this project's ruff config), which is a lint-driven cleanup, not a plan deviation.
+
+## Issues Encountered
+
+Initial test-suite flakiness under `pytest-randomly`: `_maybe_check_for_update`'s "yes -> upgrade" branch writes `PCSWITCHER_SKIP_VERSION_CHECK=1` to `os.environ` directly (as designed — it's the re-exec guard for the child process). Tests that then called `monkeypatch.delenv(..., raising=False)` afterward to clean up were, counterintuitively, causing pytest's `monkeypatch` fixture to record that mutated value as the "original" and restore it at test teardown — re-leaking `"1"` into every subsequent test in the run and silently short-circuiting later checks. Root-caused by reading `_pytest.monkeypatch.MonkeyPatch.delitem`'s source: `delenv(raising=False)` on an *absent* key records nothing, but the later cleanup call on the now-*present* key records `(dict, key, "1")` for undo, which teardown replays. Fixed by replacing all mid-test `monkeypatch.delenv`/`setenv` calls with a single autouse fixture doing plain `os.environ.pop("PCSWITCHER_SKIP_VERSION_CHECK", None)` before and after each test.
+
+## Verification
+
+`uv run ruff format --check . && uv run ruff check . && uv run basedpyright && uv run pytest tests/unit tests/contract` — all green (593 tests passed, 0 lint errors, 0 type errors). `tests/integration/test_self_update.py` (the source of the `Successfully updated`/`Already at version` exact-string assertions) was not run — it requires VM infrastructure not available in this session; the refactor was verified not to change either string via direct code inspection (RESEARCH.md Pitfall 3) and `tests/unit/cli/test_self_update.py` passes unchanged against the refactored code.
+
+## Next Phase Readiness
+
+Feature complete and self-contained within `cli.py`; no follow-on work identified. If VM integration infrastructure becomes available, running `tests/integration/test_self_update.py` would give end-to-end confirmation of the preserved exact-string assertions.
+
+---
+*Quick task: 260719-g13-check-for-new-versions-at-startup-176*
+*Completed: 2026-07-19*
+
+## Self-Check: PASSED
+
+All created/modified files found on disk (src/pcswitcher/cli.py, tests/unit/cli/test_version_check.py, README.md). All task commit hashes (800645b, 6c738f3, 647bf75) found in git log.

--- a/.planning/quick/260719-g13-check-for-new-versions-at-startup-176/260719-g13-VERIFICATION.md
+++ b/.planning/quick/260719-g13-check-for-new-versions-at-startup-176/260719-g13-VERIFICATION.md
@@ -1,0 +1,76 @@
+---
+phase: 260719-g13-check-for-new-versions-at-startup-176
+verified: 2026-07-19T00:00:00Z
+status: passed
+score: 5/5 must-haves verified
+behavior_unverified: 0
+overrides_applied: 0
+---
+
+# Quick Task 260719-g13: Check for new versions at startup (#176) Verification Report
+
+**Task Goal:** On startup, pc-switcher checks GitHub for a newer STABLE release and, in an interactive terminal, offers to upgrade-and-restart; skippable via `--no-version-check` / env / non-TTY / `self` / bare invocation; never fatal on any failure.
+
+**Verified:** 2026-07-19. **Status:** passed. **Re-verification:** No — initial verification.
+
+## Goal Achievement
+
+### Observable Truths
+
+| # | Truth | Status | Evidence |
+|---|-------|--------|----------|
+| 1 | Real subcommand in interactive terminal with newer stable release prints current-vs-available and prompts y/N | VERIFIED | `src/pcswitcher/cli.py:718-721` prints `"A new stable version... {current} -> {latest}"` then `Prompt.ask("Upgrade now?", choices=["y","n"], default="n")`. Behavioral test: `test_update_available_yes_upgrades_and_reexecs` PASSED. |
+| 2 | y installs via existing install+verify path then re-execs same argv; N continues unchanged | VERIFIED | `cli.py:725-743` calls `_install_and_verify(latest)`, sets guard env, flushes stdio, `os.execvp(sys.argv[0], sys.argv)`. N-path returns at `cli.py:723`. Tests `test_update_available_yes_upgrades_and_reexecs` (asserts `execvp` called with `(sys.argv[0], sys.argv)` and env var set) and `test_update_available_no_continues_without_reexec` (asserts `execvp` NOT called) both PASSED. |
+| 3 | Check skipped for `--no-version-check`, `PCSWITCHER_SKIP_VERSION_CHECK`, non-TTY, `self`, bare invocation, `--version` | VERIFIED | `cli.py:705` single guard covers flag/env/TTY; `cli.py:116` guards `self`/bare via `ctx.invoked_subcommand not in (None, "self")`; `--version` is Typer's `is_eager` callback (`cli.py:101-103`) which raises `typer.Exit()` before the callback body runs. Unit tests cover flag, env, non-TTY, `self`. Bare invocation and `--version` are not covered by the unit suite but were independently confirmed live in this session: `runner.invoke(cli.app, [])` and `runner.invoke(cli.app, ["--version"])` both exit without calling `_maybe_check_for_update` (mocked and asserted `.called == False`). |
+| 4 | Any check/upgrade/execvp failure warns and continues, never fatal | VERIFIED | `cli.py:708-713` (broad `except Exception`), `726-732` (`except UpdateFailedError` — warn, return, no `sys.exit`), `742-745` (`except OSError` on `execvp` — warn, falls through). Tests `test_check_raises_warns_and_continues`, `test_upgrade_fails_warns_and_continues`, `test_reexec_oserror_warns_and_continues` all PASSED, each asserting no exception propagates and a warning string is printed. |
+| 5 | `self update` still emits exact existing strings (`Successfully updated`, `Already at version`, downgrade warning, dim-stderr detail) after extraction | VERIFIED | Exact strings preserved verbatim: `cli.py:674` `"[green]Already at version {current_display}[/green]"`, `cli.py:678` downgrade warning, `cli.py:685-687` `[bold red]Error:[/bold red] {e}` + `[dim]{e.detail}[/dim]`, `cli.py:690` `"[green]Successfully updated to version {target_display}[/green]"`. `tests/unit/cli/test_self_update.py` passes unchanged against the refactored `_run_uv_tool_install`/`_verify_installed_version`. The VM-gated `tests/integration/test_self_update.py` (source of the literal assertions at lines 146, 194) was not runnable in this session — string match confirmed by direct code read, not by executing that integration test. |
+
+**Score:** 5/5 truths verified (0 present-but-behavior-unverified)
+
+### Required Artifacts
+
+| Artifact | Expected | Status | Details |
+|----------|----------|--------|---------|
+| `src/pcswitcher/cli.py` | `UpdateFailedError`, `_install_and_verify`, `_maybe_check_for_update`, `--no-version-check` option + `ctx` on `main` | VERIFIED | All four present: class at `524`, function at `576`, function at `693`, option+ctx at `97-108`. Confirmed importable and callable via `python -c` symbol check. |
+| `tests/unit/cli/test_version_check.py` | Covers every CONTEXT.md branch plus execvp-OSError fallback | VERIFIED | 13 tests, all PASSED. Covers upgrade-yes/no, already-up-to-date, ahead-of-stable, non-TTY, flag skip, env skip, check-raises, upgrade-fails, execvp-OSError, `--no-version-check` CliRunner, `self` guard (both directions). |
+| `README.md` | Documents `--no-version-check`, startup check, `PCSWITCHER_SKIP_VERSION_CHECK` | VERIFIED | Lines 132-133 (flag in Available Commands), 136-138 (Startup version check subsection), 159 (rate-limit note extended to mention the startup check). |
+
+### Key Link Verification
+
+| From | To | Via | Status | Details |
+|------|-----|-----|--------|---------|
+| `main` callback | `_maybe_check_for_update` | `ctx.invoked_subcommand not in (None, 'self')` guard | WIRED | `cli.py:116-117`; behaviorally confirmed both directions (`self` skips, `logs` invokes) via `test_self_subcommand_skips_version_check` / `test_non_self_subcommand_invokes_version_check`, plus live bare/`--version` checks in this session. |
+| `_maybe_check_for_update` + `update` | `_install_and_verify(release)` | Shared helper, fork at call sites | WIRED | `_maybe_check_for_update` at `cli.py:727` (warn+return on failure), `update` at `cli.py:683` (print+exit on failure) — same helper, different `except` bodies. |
+| Re-exec guard | `os.execvp(sys.argv[0], sys.argv)` | `PCSWITCHER_SKIP_VERSION_CHECK=1` set immediately before | WIRED | `cli.py:737-743`; test asserts env var == "1" and `execvp` called with exact argv. |
+
+### Behavioral Spot-Checks
+
+| Behavior | Command | Result | Status |
+|----------|---------|--------|--------|
+| Full unit test file | `uv run pytest tests/unit/cli/test_version_check.py -q` | 13 passed | PASS |
+| Lint | `uv run ruff check src/pcswitcher/cli.py tests/unit/cli/test_version_check.py` | All checks passed | PASS |
+| Format | `uv run ruff format --check .` | 88 files already formatted | PASS |
+| Type check | `uv run basedpyright src/pcswitcher/cli.py tests/unit/cli/test_version_check.py` | 0 errors, 0 warnings, 0 notes | PASS |
+| Symbol existence | `python -c "from pcswitcher import cli; ..."` | `UpdateFailedError`/`_install_and_verify`/`_maybe_check_for_update` all present and callable | PASS |
+| Full unit+contract suite (regression) | `uv run pytest tests/unit tests/contract -q` | 593 passed | PASS |
+| Bare invocation skip | `runner.invoke(cli.app, [])` with `_maybe_check_for_update` mocked | exit 2 (Typer help/usage), mock NOT called | PASS |
+| `--version` skip | `runner.invoke(cli.app, ["--version"])` with `_maybe_check_for_update` mocked | exit 0, prints version, mock NOT called | PASS |
+| Existing self-update unit + command suites (regression) | `uv run pytest tests/unit/cli -q` | 61 passed | PASS |
+
+### Anti-Patterns Found
+
+None. Grep for `TBD|FIXME|XXX|TODO|HACK|PLACEHOLDER|not yet implemented|coming soon` across `src/pcswitcher/cli.py` and `tests/unit/cli/test_version_check.py` returned no matches. No stub returns, no hardcoded-empty data flowing to output.
+
+### Requirements Coverage
+
+Not applicable — this is a quick task under `.planning/quick/`, not a roadmap phase; there is no ROADMAP.md success-criteria entry or `REQUIREMENTS.md` phase mapping for it. The PLAN.md frontmatter `must_haves` (verified above) constitute the full contract, tied to GitHub issue #176.
+
+### Human Verification Required
+
+None. All must-haves are either directly verified by passing unit tests or independently confirmed live in this session (bare invocation, `--version`). The one item resting on code-inspection rather than an executed test — `self update`'s exact strings, per the VM-gated integration test — is a static string-literal match (not a state-transition/cancellation invariant), fully visible via grep/read, so it does not require a behavioral test to reach VERIFIED.
+
+### Gaps Summary
+
+None found. All 5 must-have truths, all 3 artifacts, and all 3 key links verified against the actual codebase (not SUMMARY.md claims). Full regression suite (593 tests) green; lint, format, and type checks clean; no debt markers in touched files.
+
+_Verified 2026-07-19 by Claude (gsd-verifier)._

--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ pc-switcher --no-version-check <command>
 
 On every command (except `self`), in an interactive terminal, pc-switcher checks GitHub for a newer stable release and offers to upgrade and restart in place. It never runs for non-interactive/scripted invocations (stdin or stdout not a TTY), and can be disabled with `--no-version-check` or by setting `PCSWITCHER_SKIP_VERSION_CHECK`.
 
+The check never blocks your command *before* it touches the installation: if the check fails (offline, rate-limited), you decline, or `uv` cannot be launched, pc-switcher just warns and continues. Once you accept and the upgrade actually runs, it does not keep running the old process (which would be stale against the freshly installed files): on success it restarts into the new version, and if the upgrade fails or the restart cannot happen it stops and tells you how to recover (`pc-switcher self update`) or to re-run your command.
+
 ## Requirements
 
 - Ubuntu 24.04 LTS on all machines

--- a/README.md
+++ b/README.md
@@ -128,7 +128,14 @@ pc-switcher cleanup-snapshots --older-than 7d [--dry-run]
 
 # Self-update pc-switcher
 pc-switcher self update [VERSION] [--prerelease]
+
+# Skip the startup version check (applies to any command, e.g. pc-switcher --no-version-check sync <target>)
+pc-switcher --no-version-check <command>
 ```
+
+### Startup version check
+
+On every command (except `self`), in an interactive terminal, pc-switcher checks GitHub for a newer stable release and offers to upgrade and restart in place. It never runs for non-interactive/scripted invocations (stdin or stdout not a TTY), and can be disabled with `--no-version-check` or by setting `PCSWITCHER_SKIP_VERSION_CHECK`.
 
 ## Requirements
 
@@ -149,7 +156,7 @@ pc-switcher self update [VERSION] [--prerelease]
 
 ### GitHub API Rate Limits
 
-When running `pc-switcher --version`, `self update`, or sync (which installs pc-switcher on target), you may see rate limit errors like:
+When running `pc-switcher --version`, `self update`, sync (which installs pc-switcher on target), or the startup version check (runs on every command; see above), you may see rate limit errors like:
 
 ```text
 RuntimeError: Failed to fetch GitHub releases: 403 {"message": "API rate limit exceeded..."}

--- a/src/pcswitcher/cli.py
+++ b/src/pcswitcher/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import signal
 import subprocess
 import sys
@@ -14,11 +15,12 @@ from typing import Annotated
 
 import typer
 from rich.console import Console
+from rich.prompt import Prompt
 from rich.text import Text
 
 from pcswitcher.btrfs_snapshots import parse_older_than, run_snapshot_cleanup
 from pcswitcher.config import Configuration, ConfigurationError
-from pcswitcher.logger import get_latest_log_file, get_logs_directory
+from pcswitcher.logger import get_latest_log_file, get_logs_directory, is_interactive
 from pcswitcher.models import SyncAbortedByUser, SyncLockedError, SyncSession
 from pcswitcher.orchestrator import Orchestrator
 from pcswitcher.version import Release, Version, find_one_version, get_highest_release, get_this_version
@@ -93,16 +95,24 @@ def _version_callback(value: bool) -> None:
 
 @app.callback()
 def main(
+    ctx: typer.Context,
     version_flag: Annotated[
         bool,
         typer.Option("--version", "-v", callback=_version_callback, is_eager=True, help="Show version and exit"),
+    ] = False,
+    no_version_check: Annotated[
+        bool,
+        typer.Option("--no-version-check", help="Skip the startup version check"),
     ] = False,
 ) -> None:
     """PC-switcher synchronization system."""
     # Logging is configured by setup_logging() in orchestrator.py when a sync runs.
     # No basicConfig here - it would install a plain handler that bypasses the
     # queue-based pipeline and breaks TUI formatting (see ADR-010).
-    pass
+    # Skip for bare invocation (no subcommand) and for `self` (avoids a circular
+    # prompt during manual `self update`); --version is eager and never reaches here.
+    if ctx.invoked_subcommand is not None and ctx.invoked_subcommand != "self":
+        _maybe_check_for_update(console, no_version_check=no_version_check)
 
 
 def _display_log_file(log_file: Path) -> None:
@@ -509,6 +519,20 @@ def init(
 GITHUB_REPO_URL = "https://github.com/flaksit/pc-switcher"
 
 
+class UpdateFailedError(Exception):
+    """Raised when installing/verifying a new pc-switcher release fails.
+
+    The optional `detail` carries install stderr so a call site can still
+    render it as a second, dimmed line (matching the pre-refactor `self
+    update` output).
+    """
+
+    def __init__(self, message: str, *, detail: str | None = None) -> None:
+        """Store `message` as the exception text and `detail` for optional display."""
+        super().__init__(message)
+        self.detail = detail
+
+
 def _run_uv_tool_install(release: Release) -> subprocess.CompletedProcess[str]:
     """Run uv tool install to install/upgrade pc-switcher.
 
@@ -545,6 +569,40 @@ def _verify_installed_version() -> Version | None:
         except ValueError:
             return None
     return None
+
+
+def _install_and_verify(release: Release) -> Version:
+    """Install `release` via `uv tool install` and verify it took effect.
+
+    Shared core reused by both `self update` (exit-on-failure) and the
+    startup auto-upgrade (warn-and-continue) — the behavioral fork on
+    failure lives at the call sites, not here. No user-facing "Updating..."
+    / "Successfully..." prints happen in this helper.
+
+    Args:
+        release: Release to install.
+
+    Returns:
+        The verified installed Version.
+
+    Raises:
+        UpdateFailedError: If install, verification, or the post-install
+            version check fails.
+    """
+    result = _run_uv_tool_install(release)
+    if result.returncode != 0:
+        raise UpdateFailedError("Update failed", detail=(result.stderr.strip() or None))
+
+    installed = _verify_installed_version()
+    if installed is None:
+        raise UpdateFailedError("Verification failed - pc-switcher not working after update")
+
+    if installed != release.version:
+        raise UpdateFailedError(
+            f"Version mismatch after update. Expected {release.version.semver_str()}, got {installed.semver_str()}"
+        )
+
+    return installed
 
 
 def _get_current_version_or_exit() -> Version:
@@ -619,28 +677,70 @@ def update(
 
     # Perform the update
     console.print(f"Updating pc-switcher from {current_display} to {target_display}...")
-    result = _run_uv_tool_install(target_release)
-
-    if result.returncode != 0:
-        console.print("[bold red]Error:[/bold red] Update failed")
-        if result.stderr:
-            console.print(f"[dim]{result.stderr.strip()}[/dim]")
-        sys.exit(1)
-
-    # Verify installation
-    installed = _verify_installed_version()
-    if installed is None:
-        console.print("[bold red]Error:[/bold red] Verification failed - pc-switcher not working after update")
-        sys.exit(1)
-
-    if installed != target_release.version:
-        console.print(
-            f"[bold red]Error:[/bold red] Version mismatch after update. "
-            f"Expected {target_display}, got {installed.semver_str()}"
-        )
+    try:
+        _install_and_verify(target_release)
+    except UpdateFailedError as e:
+        console.print(f"[bold red]Error:[/bold red] {e}")
+        if e.detail:
+            console.print(f"[dim]{e.detail}[/dim]")
         sys.exit(1)
 
     console.print(f"[green]Successfully updated to version {target_display}[/green]")
+
+
+def _maybe_check_for_update(console: Console, *, no_version_check: bool) -> None:
+    """Best-effort startup check for a newer stable release; offer to upgrade inline.
+
+    Never fatal: any check failure, upgrade failure, or re-exec failure prints
+    a warning and returns so the invoking command proceeds unaffected. Skips
+    entirely for `--no-version-check`, `PCSWITCHER_SKIP_VERSION_CHECK`, and
+    non-interactive runs (either stdin or stdout not a TTY).
+
+    Args:
+        console: Rich console to print status to.
+        no_version_check: If True, skip the check (from `--no-version-check`).
+    """
+    if no_version_check or os.environ.get("PCSWITCHER_SKIP_VERSION_CHECK") or not is_interactive(console):
+        return
+
+    try:
+        current = get_this_version()
+        latest = get_highest_release(include_prereleases=False)
+    except Exception as e:
+        console.print(f"[yellow]Warning:[/yellow] Could not check for updates: {e}")
+        return
+
+    if latest.version <= current:
+        return
+
+    console.print(
+        f"A new stable version of pc-switcher is available: {current.semver_str()} -> {latest.version.semver_str()}"
+    )
+    response = Prompt.ask("Upgrade now?", choices=["y", "n"], default="n")
+    if response.lower() != "y":
+        return
+
+    console.print(f"Updating pc-switcher to {latest.version.semver_str()}...")
+    try:
+        _install_and_verify(latest)
+    except UpdateFailedError as e:
+        console.print(f"[yellow]Warning:[/yellow] {e}")
+        if e.detail:
+            console.print(f"[dim]{e.detail}[/dim]")
+        return
+
+    console.print("[green]Updated.[/green] Restarting with the new version...")
+    # Set right before exec so this run's own check never saw it - it's only
+    # meant for the re-exec'd child, preventing an infinite check loop.
+    os.environ["PCSWITCHER_SKIP_VERSION_CHECK"] = "1"
+    # execvp does not flush Python's buffered I/O before replacing the process
+    # image, so flush explicitly or the messages above could be lost.
+    sys.stdout.flush()
+    sys.stderr.flush()
+    try:
+        os.execvp(sys.argv[0], sys.argv)
+    except OSError as e:
+        console.print(f"[yellow]Warning:[/yellow] Could not restart automatically: {e}")
 
 
 if __name__ == "__main__":

--- a/src/pcswitcher/cli.py
+++ b/src/pcswitcher/cli.py
@@ -20,9 +20,10 @@ from rich.text import Text
 
 from pcswitcher.btrfs_snapshots import parse_older_than, run_snapshot_cleanup
 from pcswitcher.config import Configuration, ConfigurationError
-from pcswitcher.logger import get_latest_log_file, get_logs_directory, is_interactive
+from pcswitcher.logger import get_latest_log_file, get_logs_directory
 from pcswitcher.models import SyncAbortedByUser, SyncLockedError, SyncSession
 from pcswitcher.orchestrator import Orchestrator
+from pcswitcher.terminal import is_interactive
 from pcswitcher.version import Release, Version, find_one_version, get_highest_release, get_this_version
 
 # Create Typer app

--- a/src/pcswitcher/cli.py
+++ b/src/pcswitcher/cli.py
@@ -96,7 +96,9 @@ def _version_callback(value: bool) -> None:
 @app.callback()
 def main(
     ctx: typer.Context,
-    version_flag: Annotated[
+    # Only registers the eager --version callback; never read in the body, hence the
+    # leading underscore (Typer takes the flag names from the Option, not the param name).
+    _version_flag: Annotated[
         bool,
         typer.Option("--version", "-v", callback=_version_callback, is_eager=True, help="Show version and exit"),
     ] = False,

--- a/src/pcswitcher/cli.py
+++ b/src/pcswitcher/cli.py
@@ -522,7 +522,13 @@ GITHUB_REPO_URL = "https://github.com/flaksit/pc-switcher"
 
 
 class UpdateFailedError(Exception):
-    """Raised when installing/verifying a new pc-switcher release fails.
+    """Raised when a started install/verify of a new release fails.
+
+    IMPORTANT: this means `uv tool install` HAS run and may have modified the
+    on-disk installation, even though it did not end in a verified-good state.
+    A currently-running process is therefore potentially stale (a later lazy
+    import could load a mismatched new module), so callers must NOT keep
+    executing after this — exit and let the user recover.
 
     The optional `detail` carries install stderr so a call site can still
     render it as a second, dimmed line (matching the pre-refactor `self
@@ -533,6 +539,15 @@ class UpdateFailedError(Exception):
         """Store `message` as the exception text and `detail` for optional display."""
         super().__init__(message)
         self.detail = detail
+
+
+class UpgradeNotStartedError(Exception):
+    """Raised when the upgrade could not even be launched (e.g. `uv` not on PATH).
+
+    Distinct from `UpdateFailedError`: `uv tool install` never executed, so the
+    on-disk installation is UNCHANGED. The running process is not stale, so a
+    caller may safely warn and continue on the current version.
+    """
 
 
 def _run_uv_tool_install(release: Release) -> subprocess.CompletedProcess[str]:
@@ -588,14 +603,30 @@ def _install_and_verify(release: Release) -> Version:
         The verified installed Version.
 
     Raises:
-        UpdateFailedError: If install, verification, or the post-install
-            version check fails.
+        UpgradeNotStartedError: If `uv` could not be launched at all, so the
+            on-disk install is untouched (caller may safely continue).
+        UpdateFailedError: If `uv` ran but the install or the post-install
+            verification failed, so the on-disk install may have been modified
+            (caller must not keep running).
     """
-    result = _run_uv_tool_install(release)
+    # Anything before uv actually runs leaves the on-disk install untouched.
+    try:
+        result = _run_uv_tool_install(release)
+    except OSError as e:
+        # subprocess could not spawn `uv` (e.g. FileNotFoundError, not on PATH):
+        # nothing was written to disk.
+        raise UpgradeNotStartedError(str(e)) from e
+
+    # From here on, uv HAS run and may have altered the on-disk installation, so
+    # every failure below is an UpdateFailedError (disk-touched), never continuable.
     if result.returncode != 0:
         raise UpdateFailedError("Update failed", detail=(result.stderr.strip() or None))
 
-    installed = _verify_installed_version()
+    try:
+        installed = _verify_installed_version()
+    except OSError as e:
+        raise UpdateFailedError(f"Could not verify the update: {e}") from e
+
     if installed is None:
         raise UpdateFailedError("Verification failed - pc-switcher not working after update")
 
@@ -681,15 +712,15 @@ def update(
     console.print(f"Updating pc-switcher from {current_display} to {target_display}...")
     try:
         _install_and_verify(target_release)
+    except UpgradeNotStartedError as e:
+        # `uv` missing from PATH or otherwise unspawnable — surface a clean error
+        # instead of a raw traceback. Nothing was installed.
+        console.print(f"[bold red]Error:[/bold red] Could not run the upgrade: {e}")
+        sys.exit(1)
     except UpdateFailedError as e:
         console.print(f"[bold red]Error:[/bold red] {e}")
         if e.detail:
             console.print(f"[dim]{e.detail}[/dim]")
-        sys.exit(1)
-    except OSError as e:
-        # `uv` missing from PATH (FileNotFoundError) or otherwise unspawnable —
-        # surface a clean error instead of a raw traceback.
-        console.print(f"[bold red]Error:[/bold red] Could not run the upgrade: {e}")
         sys.exit(1)
 
     console.print(f"[green]Successfully updated to version {target_display}[/green]")
@@ -698,15 +729,27 @@ def update(
 def _maybe_check_for_update(console: Console, *, no_version_check: bool) -> None:
     """Best-effort startup check for a newer stable release; offer to upgrade inline.
 
-    Never fatal: any check failure, upgrade failure, or re-exec failure prints
-    a warning and returns so the invoking command proceeds unaffected. Skips
-    entirely for `--no-version-check`, `PCSWITCHER_SKIP_VERSION_CHECK`, a help
-    request (`--help`/`-h`), and non-interactive runs (either stdin or stdout
-    not a TTY).
+    Non-fatal ONLY up to the point the on-disk installation is modified. Once
+    `uv tool install` runs, the current process may be stale (a later lazy
+    import would load a mismatched new module), so we must not keep executing:
+    on a successful upgrade we re-exec the new binary, and on any failure after
+    the install started we exit and tell the user how to recover. Everything
+    before that boundary (check failure, offline, declined prompt, or `uv` not
+    even launchable) warns and lets the current command proceed.
+
+    Skips entirely for `--no-version-check`, `PCSWITCHER_SKIP_VERSION_CHECK`, a
+    help request (`--help`/`-h`), and non-interactive runs (either stdin or
+    stdout not a TTY).
 
     Args:
         console: Rich console to print status to.
         no_version_check: If True, skip the check (from `--no-version-check`).
+
+    Raises:
+        typer.Exit: After the install has touched disk and either failed
+            (recover via `self update`) or succeeded but the automatic restart
+            could not happen (re-run the command). Never raised before the
+            install is attempted.
     """
     # A help request would otherwise block on the upgrade prompt before the help
     # text renders; `pc-switcher <cmd> --help` should print help immediately.
@@ -738,18 +781,24 @@ def _maybe_check_for_update(console: Console, *, no_version_check: bool) -> None
 
     console.print(f"Updating pc-switcher to {latest.version.semver_str()}...")
     try:
-        _install_and_verify(latest)
+        installed = _install_and_verify(latest)
+    except UpgradeNotStartedError as e:
+        # `uv` never ran (e.g. not on PATH): the on-disk install is untouched, so
+        # the current process is not stale — warn and let the command proceed.
+        console.print(f"[yellow]Warning:[/yellow] Could not run the upgrade: {e}. Continuing on the current version.")
+        return
     except UpdateFailedError as e:
-        console.print(f"[yellow]Warning:[/yellow] {e}")
+        # uv already modified the on-disk install but it did not end verified-good.
+        # The running process may now be stale, so we must NOT continue: exit and
+        # point the user at a clean recovery.
+        console.print(f"[bold red]Error:[/bold red] Upgrade failed: {e}")
         if e.detail:
             console.print(f"[dim]{e.detail}[/dim]")
-        return
-    except OSError as e:
-        # subprocess.run raises OSError (e.g. FileNotFoundError when `uv` is not
-        # on PATH) before any exit code. Must stay non-fatal: warn and let the
-        # user's actual command proceed on the current version.
-        console.print(f"[yellow]Warning:[/yellow] Could not run the upgrade: {e}")
-        return
+        console.print(
+            "The installation may be in an inconsistent state. Run "
+            "[cyan]pc-switcher self update[/cyan] to restore a known-good version, then retry."
+        )
+        raise typer.Exit(1) from e
 
     console.print("[green]Updated.[/green] Restarting with the new version...")
     # Set right before exec so this run's own check never saw it - it's only
@@ -762,7 +811,15 @@ def _maybe_check_for_update(console: Console, *, no_version_check: bool) -> None
     try:
         os.execvp(sys.argv[0], sys.argv)
     except OSError as e:
-        console.print(f"[yellow]Warning:[/yellow] Could not restart automatically: {e}")
+        # Exec failed, so the process image was NOT replaced - but the new version
+        # is already installed and verified on disk, making the current in-memory
+        # process stale. Do not continue it (a later lazy import could load the new,
+        # mismatched code); exit and let the user re-run under the new binary.
+        console.print(
+            f"[bold red]Error:[/bold red] Upgraded to {installed.semver_str()}, but could not restart "
+            f"automatically ({e}). Please re-run your command."
+        )
+        raise typer.Exit(1) from e
 
 
 if __name__ == "__main__":

--- a/src/pcswitcher/cli.py
+++ b/src/pcswitcher/cli.py
@@ -686,6 +686,11 @@ def update(
         if e.detail:
             console.print(f"[dim]{e.detail}[/dim]")
         sys.exit(1)
+    except OSError as e:
+        # `uv` missing from PATH (FileNotFoundError) or otherwise unspawnable —
+        # surface a clean error instead of a raw traceback.
+        console.print(f"[bold red]Error:[/bold red] Could not run the upgrade: {e}")
+        sys.exit(1)
 
     console.print(f"[green]Successfully updated to version {target_display}[/green]")
 
@@ -695,14 +700,23 @@ def _maybe_check_for_update(console: Console, *, no_version_check: bool) -> None
 
     Never fatal: any check failure, upgrade failure, or re-exec failure prints
     a warning and returns so the invoking command proceeds unaffected. Skips
-    entirely for `--no-version-check`, `PCSWITCHER_SKIP_VERSION_CHECK`, and
-    non-interactive runs (either stdin or stdout not a TTY).
+    entirely for `--no-version-check`, `PCSWITCHER_SKIP_VERSION_CHECK`, a help
+    request (`--help`/`-h`), and non-interactive runs (either stdin or stdout
+    not a TTY).
 
     Args:
         console: Rich console to print status to.
         no_version_check: If True, skip the check (from `--no-version-check`).
     """
-    if no_version_check or os.environ.get("PCSWITCHER_SKIP_VERSION_CHECK") or not is_interactive(console):
+    # A help request would otherwise block on the upgrade prompt before the help
+    # text renders; `pc-switcher <cmd> --help` should print help immediately.
+    help_requested = "--help" in sys.argv or "-h" in sys.argv
+    if (
+        no_version_check
+        or help_requested
+        or os.environ.get("PCSWITCHER_SKIP_VERSION_CHECK")
+        or not is_interactive(console)
+    ):
         return
 
     try:
@@ -729,6 +743,12 @@ def _maybe_check_for_update(console: Console, *, no_version_check: bool) -> None
         console.print(f"[yellow]Warning:[/yellow] {e}")
         if e.detail:
             console.print(f"[dim]{e.detail}[/dim]")
+        return
+    except OSError as e:
+        # subprocess.run raises OSError (e.g. FileNotFoundError when `uv` is not
+        # on PATH) before any exit code. Must stay non-fatal: warn and let the
+        # user's actual command proceed on the current version.
+        console.print(f"[yellow]Warning:[/yellow] Could not run the upgrade: {e}")
         return
 
     console.print("[green]Updated.[/green] Restarting with the new version...")

--- a/src/pcswitcher/confirmer.py
+++ b/src/pcswitcher/confirmer.py
@@ -26,7 +26,7 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.prompt import Prompt
 
-from pcswitcher.logger import is_interactive
+from pcswitcher.terminal import is_interactive
 
 __all__ = ["Confirmer", "PausableUI", "TerminalUIConfirmer"]
 

--- a/src/pcswitcher/logger.py
+++ b/src/pcswitcher/logger.py
@@ -18,6 +18,7 @@ from rich.console import Console
 from rich.text import Text
 
 from pcswitcher.config import LogConfig
+from pcswitcher.terminal import is_interactive
 
 # Register custom FULL level (15) with stdlib logging
 FULL = 15
@@ -319,20 +320,6 @@ class WarningCaptureHandler(logging.Handler):
             self._sink.add_warning(format_log_line(record))
         except Exception:
             self.handleError(record)
-
-
-def is_interactive(console: Console) -> bool:
-    """Return True only when the run is fully interactive on both stdin and stdout.
-
-    A run is interactive only if BOTH ends are a terminal: a real terminal on
-    stdout (``console.is_terminal``) so a live UI / prompt is actually visible,
-    AND a TTY on stdin (``sys.stdin.isatty()``) so the user can actually answer
-    a prompt. Requiring both keeps logging setup and the confirmer in agreement
-    under mixed redirection (e.g. stdout is a TTY but stdin is ``/dev/null``):
-    a single split signal previously let the live UI + UILogHandler activate
-    while confirmations silently fell back to ``--allow-*`` flags.
-    """
-    return console.is_terminal and sys.stdin.isatty()
 
 
 def generate_log_filename(session_id: str) -> str:

--- a/src/pcswitcher/terminal.py
+++ b/src/pcswitcher/terminal.py
@@ -1,0 +1,21 @@
+"""Terminal capability checks shared across pc-switcher."""
+
+from __future__ import annotations
+
+import sys
+
+from rich.console import Console
+
+
+def is_interactive(console: Console) -> bool:
+    """Return True only when the run is fully interactive on both stdin and stdout.
+
+    A run is interactive only if BOTH ends are a terminal: a real terminal on
+    stdout (``console.is_terminal``) so a live UI / prompt is actually visible,
+    AND a TTY on stdin (``sys.stdin.isatty()``) so the user can actually answer
+    a prompt. Requiring both keeps logging setup and the confirmer in agreement
+    under mixed redirection (e.g. stdout is a TTY but stdin is ``/dev/null``):
+    a single split signal previously let the live UI + UILogHandler activate
+    while confirmations silently fell back to ``--allow-*`` flags.
+    """
+    return console.is_terminal and sys.stdin.isatty()

--- a/tests/unit/cli/test_version_check.py
+++ b/tests/unit/cli/test_version_check.py
@@ -20,6 +20,7 @@ from collections.abc import Callable, Generator
 from unittest.mock import MagicMock, patch
 
 import pytest
+import typer
 from rich.console import Console
 from typer.testing import CliRunner
 
@@ -190,7 +191,12 @@ class TestMaybeCheckForUpdateSkipConditions:
 
 
 class TestMaybeCheckForUpdateFailureFallbacks:
-    """check raises; upgrade fails; execvp OSError - all warn and continue, never fatal."""
+    """Failure handling, scoped to the disk-mutation boundary.
+
+    Before `uv` touches the install (check error, `uv` not launchable) → warn +
+    continue. Once `uv` has run (upgrade failed, or succeeded but re-exec failed)
+    → exit rather than keep running a now-stale process (#176).
+    """
 
     def test_check_raises_warns_and_continues(self) -> None:
         """A RuntimeError from get_highest_release (offline/rate-limit/API) is swallowed."""
@@ -208,25 +214,13 @@ class TestMaybeCheckForUpdateFailureFallbacks:
         mock_execvp.assert_not_called()
         assert "warning" in console.file.getvalue().lower()  # pyright: ignore[reportAttributeAccessIssue]
 
-    def test_upgrade_fails_warns_and_continues(self) -> None:
-        """Accepting the prompt but the install failing warns and returns (no SystemExit)."""
-        console = _capture_console()
-        failed_install = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="install exploded")
-        with (
-            patch("pcswitcher.cli.is_interactive", return_value=True),
-            patch("pcswitcher.cli.get_this_version", return_value=CURRENT_VERSION),
-            patch("pcswitcher.cli.get_highest_release", return_value=HIGHER_RELEASE),
-            patch("pcswitcher.cli.Prompt.ask", return_value="y"),
-            patch("pcswitcher.cli.subprocess.run", return_value=failed_install),
-            patch("pcswitcher.cli.os.execvp") as mock_execvp,
-        ):
-            cli._maybe_check_for_update(console, no_version_check=False)  # pyright: ignore[reportPrivateUsage]
+    def test_uv_not_launchable_warns_and_continues(self) -> None:
+        """`uv` missing from PATH raises before any disk write, so the command still runs (#176).
 
-        mock_execvp.assert_not_called()
-        assert "warning" in console.file.getvalue().lower()  # pyright: ignore[reportAttributeAccessIssue]
-
-    def test_upgrade_oserror_warns_and_continues(self) -> None:
-        """`uv` missing from PATH makes subprocess.run raise OSError; must not crash startup (CR-01, #176)."""
+        subprocess.run raising FileNotFoundError means `uv` never executed - the
+        on-disk install is untouched, so the current process is not stale and we
+        warn + continue rather than exit.
+        """
         console = _capture_console()
         with (
             patch("pcswitcher.cli.is_interactive", return_value=True),
@@ -236,14 +230,34 @@ class TestMaybeCheckForUpdateFailureFallbacks:
             patch("pcswitcher.cli.subprocess.run", side_effect=FileNotFoundError("uv not found")),
             patch("pcswitcher.cli.os.execvp") as mock_execvp,
         ):
-            # Must return normally (never propagate) so the invoking command still runs.
+            # Must return normally (no typer.Exit) so the invoking command still runs.
             cli._maybe_check_for_update(console, no_version_check=False)  # pyright: ignore[reportPrivateUsage]
 
         mock_execvp.assert_not_called()
         assert "warning" in console.file.getvalue().lower()  # pyright: ignore[reportAttributeAccessIssue]
 
-    def test_reexec_oserror_warns_and_continues(self) -> None:
-        """A successful install followed by execvp raising OSError is swallowed, not propagated."""
+    def test_upgrade_fails_after_install_exits_with_recovery_hint(self) -> None:
+        """A non-zero `uv` install already touched disk: exit (not continue) with a recovery hint (#176)."""
+        console = _capture_console()
+        failed_install = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="install exploded")
+        with (
+            patch("pcswitcher.cli.is_interactive", return_value=True),
+            patch("pcswitcher.cli.get_this_version", return_value=CURRENT_VERSION),
+            patch("pcswitcher.cli.get_highest_release", return_value=HIGHER_RELEASE),
+            patch("pcswitcher.cli.Prompt.ask", return_value="y"),
+            patch("pcswitcher.cli.subprocess.run", return_value=failed_install),
+            patch("pcswitcher.cli.os.execvp") as mock_execvp,
+            pytest.raises(typer.Exit) as exc_info,
+        ):
+            cli._maybe_check_for_update(console, no_version_check=False)  # pyright: ignore[reportPrivateUsage]
+
+        assert exc_info.value.exit_code == 1
+        mock_execvp.assert_not_called()
+        output = console.file.getvalue()  # pyright: ignore[reportAttributeAccessIssue]
+        assert "self update" in output  # recovery hint present
+
+    def test_reexec_oserror_exits_asking_rerun(self) -> None:
+        """A verified install then an execvp OSError must exit, asking to re-run, not continue stale (#176)."""
         console = _capture_console()
         with (
             patch("pcswitcher.cli.is_interactive", return_value=True),
@@ -252,11 +266,13 @@ class TestMaybeCheckForUpdateFailureFallbacks:
             patch("pcswitcher.cli.Prompt.ask", return_value="y"),
             patch("pcswitcher.cli.subprocess.run", side_effect=_subprocess_side_effect("pc-switcher 1.1.0")),
             patch("pcswitcher.cli.os.execvp", side_effect=OSError("no such file")) as mock_execvp,
+            pytest.raises(typer.Exit) as exc_info,
         ):
             cli._maybe_check_for_update(console, no_version_check=False)  # pyright: ignore[reportPrivateUsage]
 
+        assert exc_info.value.exit_code == 1
         mock_execvp.assert_called_once()
-        assert "warning" in console.file.getvalue().lower()  # pyright: ignore[reportAttributeAccessIssue]
+        assert "re-run" in console.file.getvalue().lower()  # pyright: ignore[reportAttributeAccessIssue]
 
 
 class TestMainCallbackWiring:

--- a/tests/unit/cli/test_version_check.py
+++ b/tests/unit/cli/test_version_check.py
@@ -1,0 +1,269 @@
+"""Tests for the startup version check (#176).
+
+Covers `_maybe_check_for_update` (direct-call style, mirroring
+test_self_update.py) and the Typer-wiring cases that depend on Click's
+context handling (`--no-version-check`, the `self`-subcommand guard;
+CliRunner style, mirroring test_commands.py).
+
+CRITICAL: every test that reaches the "yes -> upgrade" branch patches
+`pcswitcher.cli.os.execvp` - an unpatched execvp replaces the pytest
+process and silently kills the run.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import subprocess
+import sys
+from collections.abc import Callable, Generator
+from unittest.mock import MagicMock, patch
+
+import pytest
+from rich.console import Console
+from typer.testing import CliRunner
+
+from pcswitcher import cli
+from pcswitcher.version import Release, Version
+
+runner = CliRunner()
+
+CURRENT_VERSION = Version.parse("1.0.0")
+HIGHER_RELEASE = Release(Version.parse("1.1.0"), is_prerelease=False, tag="v1.1.0")
+SAME_RELEASE = Release(Version.parse("1.0.0"), is_prerelease=False, tag="v1.0.0")
+LOWER_RELEASE = Release(Version.parse("0.9.0"), is_prerelease=False, tag="v0.9.0")
+
+_SKIP_ENV_VAR = "PCSWITCHER_SKIP_VERSION_CHECK"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_skip_env_var() -> Generator[None]:  # pyright: ignore[reportUnusedFunction]
+    """Guarantee PCSWITCHER_SKIP_VERSION_CHECK doesn't leak across tests.
+
+    The "yes -> upgrade" code path writes directly to `os.environ` (the
+    re-exec guard) rather than through `monkeypatch.setenv`. Calling
+    `monkeypatch.delenv` afterwards to clean that up is a footgun: monkeypatch
+    would record the mutated value as the "original" and restore it at
+    teardown, re-leaking it into the next test. Plain dict manipulation here
+    avoids that entirely.
+    """
+    os.environ.pop(_SKIP_ENV_VAR, None)
+    yield
+    os.environ.pop(_SKIP_ENV_VAR, None)
+
+
+def _capture_console() -> Console:
+    """Build a Rich console that force-renders into an in-memory buffer.
+
+    force_terminal ensures Rich's own markup renders, not `console.is_terminal`
+    for the TTY gate - that gate is controlled separately via
+    `patch("pcswitcher.cli.is_interactive", ...)` so tests are deterministic
+    regardless of StringIO's own terminal detection.
+    """
+    return Console(file=io.StringIO(), force_terminal=True)
+
+
+def _subprocess_side_effect(version_stdout: str) -> Callable[..., subprocess.CompletedProcess[str]]:
+    """Route `uv tool install` and `pc-switcher --version` subprocess.run calls to success results."""
+
+    def _side_effect(cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        if cmd[0] == "uv":
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="Installed", stderr="")
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=version_stdout, stderr="")
+
+    return _side_effect
+
+
+class TestMaybeCheckForUpdateUpgradeFlow:
+    """update available -> yes -> upgrade + re-exec; and the decline path."""
+
+    def test_update_available_yes_upgrades_and_reexecs(self) -> None:
+        """Accepting the prompt installs the release, sets the guard env var, and re-execs."""
+        console = _capture_console()
+        with (
+            patch("pcswitcher.cli.is_interactive", return_value=True),
+            patch("pcswitcher.cli.get_this_version", return_value=CURRENT_VERSION),
+            patch("pcswitcher.cli.get_highest_release", return_value=HIGHER_RELEASE),
+            patch("pcswitcher.cli.Prompt.ask", return_value="y"),
+            patch("pcswitcher.cli.subprocess.run", side_effect=_subprocess_side_effect("pc-switcher 1.1.0")),
+            patch("pcswitcher.cli.os.execvp") as mock_execvp,
+        ):
+            cli._maybe_check_for_update(console, no_version_check=False)  # pyright: ignore[reportPrivateUsage]
+
+        mock_execvp.assert_called_once_with(sys.argv[0], sys.argv)
+        assert os.environ[_SKIP_ENV_VAR] == "1"
+
+    def test_update_available_no_continues_without_reexec(self) -> None:
+        """Declining the prompt returns without installing or re-executing."""
+        console = _capture_console()
+        with (
+            patch("pcswitcher.cli.is_interactive", return_value=True),
+            patch("pcswitcher.cli.get_this_version", return_value=CURRENT_VERSION),
+            patch("pcswitcher.cli.get_highest_release", return_value=HIGHER_RELEASE),
+            patch("pcswitcher.cli.Prompt.ask", return_value="n") as mock_prompt,
+            patch("pcswitcher.cli.os.execvp") as mock_execvp,
+        ):
+            cli._maybe_check_for_update(console, no_version_check=False)  # pyright: ignore[reportPrivateUsage]
+
+        mock_prompt.assert_called_once()
+        mock_execvp.assert_not_called()
+
+
+class TestMaybeCheckForUpdateNoPromptCases:
+    """already up to date -> no prompt; non-TTY -> skip."""
+
+    def test_already_up_to_date_no_prompt(self) -> None:
+        """When latest stable <= current, the prompt is never shown."""
+        console = _capture_console()
+        with (
+            patch("pcswitcher.cli.is_interactive", return_value=True),
+            patch("pcswitcher.cli.get_this_version", return_value=CURRENT_VERSION),
+            patch("pcswitcher.cli.get_highest_release", return_value=SAME_RELEASE),
+            patch("pcswitcher.cli.Prompt.ask") as mock_prompt,
+        ):
+            cli._maybe_check_for_update(console, no_version_check=False)  # pyright: ignore[reportPrivateUsage]
+
+        mock_prompt.assert_not_called()
+
+    def test_current_ahead_of_stable_no_prompt(self) -> None:
+        """Running a dev build ahead of the latest stable release never prompts."""
+        console = _capture_console()
+        with (
+            patch("pcswitcher.cli.is_interactive", return_value=True),
+            patch("pcswitcher.cli.get_this_version", return_value=CURRENT_VERSION),
+            patch("pcswitcher.cli.get_highest_release", return_value=LOWER_RELEASE),
+            patch("pcswitcher.cli.Prompt.ask") as mock_prompt,
+        ):
+            cli._maybe_check_for_update(console, no_version_check=False)  # pyright: ignore[reportPrivateUsage]
+
+        mock_prompt.assert_not_called()
+
+    def test_non_tty_skips_check_entirely(self) -> None:
+        """When not fully interactive, the check never even fetches releases."""
+        console = _capture_console()
+        with (
+            patch("pcswitcher.cli.is_interactive", return_value=False),
+            patch("pcswitcher.cli.get_highest_release") as mock_get_highest,
+        ):
+            cli._maybe_check_for_update(console, no_version_check=False)  # pyright: ignore[reportPrivateUsage]
+
+        mock_get_highest.assert_not_called()
+
+
+class TestMaybeCheckForUpdateSkipConditions:
+    """`--no-version-check` (function-level) and `PCSWITCHER_SKIP_VERSION_CHECK` env skip."""
+
+    def test_no_version_check_flag_skips(self) -> None:
+        """Passing no_version_check=True short-circuits before any fetch."""
+        console = _capture_console()
+        with (
+            patch("pcswitcher.cli.is_interactive", return_value=True),
+            patch("pcswitcher.cli.get_highest_release") as mock_get_highest,
+        ):
+            cli._maybe_check_for_update(console, no_version_check=True)  # pyright: ignore[reportPrivateUsage]
+
+        mock_get_highest.assert_not_called()
+
+    def test_env_var_set_skips(self) -> None:
+        """PCSWITCHER_SKIP_VERSION_CHECK being set skips the check entirely."""
+        os.environ[_SKIP_ENV_VAR] = "1"
+        console = _capture_console()
+        with (
+            patch("pcswitcher.cli.is_interactive", return_value=True),
+            patch("pcswitcher.cli.get_highest_release") as mock_get_highest,
+        ):
+            cli._maybe_check_for_update(console, no_version_check=False)  # pyright: ignore[reportPrivateUsage]
+
+        mock_get_highest.assert_not_called()
+
+
+class TestMaybeCheckForUpdateFailureFallbacks:
+    """check raises; upgrade fails; execvp OSError - all warn and continue, never fatal."""
+
+    def test_check_raises_warns_and_continues(self) -> None:
+        """A RuntimeError from get_highest_release (offline/rate-limit/API) is swallowed."""
+        console = _capture_console()
+        with (
+            patch("pcswitcher.cli.is_interactive", return_value=True),
+            patch("pcswitcher.cli.get_this_version", return_value=CURRENT_VERSION),
+            patch("pcswitcher.cli.get_highest_release", side_effect=RuntimeError("offline")),
+            patch("pcswitcher.cli.Prompt.ask") as mock_prompt,
+            patch("pcswitcher.cli.os.execvp") as mock_execvp,
+        ):
+            cli._maybe_check_for_update(console, no_version_check=False)  # pyright: ignore[reportPrivateUsage]
+
+        mock_prompt.assert_not_called()
+        mock_execvp.assert_not_called()
+        assert "warning" in console.file.getvalue().lower()  # pyright: ignore[reportAttributeAccessIssue]
+
+    def test_upgrade_fails_warns_and_continues(self) -> None:
+        """Accepting the prompt but the install failing warns and returns (no SystemExit)."""
+        console = _capture_console()
+        failed_install = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="install exploded")
+        with (
+            patch("pcswitcher.cli.is_interactive", return_value=True),
+            patch("pcswitcher.cli.get_this_version", return_value=CURRENT_VERSION),
+            patch("pcswitcher.cli.get_highest_release", return_value=HIGHER_RELEASE),
+            patch("pcswitcher.cli.Prompt.ask", return_value="y"),
+            patch("pcswitcher.cli.subprocess.run", return_value=failed_install),
+            patch("pcswitcher.cli.os.execvp") as mock_execvp,
+        ):
+            cli._maybe_check_for_update(console, no_version_check=False)  # pyright: ignore[reportPrivateUsage]
+
+        mock_execvp.assert_not_called()
+        assert "warning" in console.file.getvalue().lower()  # pyright: ignore[reportAttributeAccessIssue]
+
+    def test_reexec_oserror_warns_and_continues(self) -> None:
+        """A successful install followed by execvp raising OSError is swallowed, not propagated."""
+        console = _capture_console()
+        with (
+            patch("pcswitcher.cli.is_interactive", return_value=True),
+            patch("pcswitcher.cli.get_this_version", return_value=CURRENT_VERSION),
+            patch("pcswitcher.cli.get_highest_release", return_value=HIGHER_RELEASE),
+            patch("pcswitcher.cli.Prompt.ask", return_value="y"),
+            patch("pcswitcher.cli.subprocess.run", side_effect=_subprocess_side_effect("pc-switcher 1.1.0")),
+            patch("pcswitcher.cli.os.execvp", side_effect=OSError("no such file")) as mock_execvp,
+        ):
+            cli._maybe_check_for_update(console, no_version_check=False)  # pyright: ignore[reportPrivateUsage]
+
+        mock_execvp.assert_called_once()
+        assert "warning" in console.file.getvalue().lower()  # pyright: ignore[reportAttributeAccessIssue]
+
+
+class TestMainCallbackWiring:
+    """Typer/Click context wiring: --no-version-check flag and the `self`-subcommand guard."""
+
+    def test_no_version_check_flag_short_circuits_before_fetch(self) -> None:
+        """`pc-switcher --no-version-check logs` never calls get_highest_release."""
+        with (
+            patch("pcswitcher.cli.is_interactive", return_value=True),
+            patch("pcswitcher.cli.get_highest_release") as mock_get_highest,
+            patch("pcswitcher.cli.get_logs_directory", return_value=MagicMock(exists=lambda: False)),
+        ):
+            result = runner.invoke(cli.app, ["--no-version-check", "logs"])
+
+        assert result.exit_code == 0, result.stdout
+        mock_get_highest.assert_not_called()
+
+    def test_self_subcommand_skips_version_check(self) -> None:
+        """`pc-switcher self update` never calls _maybe_check_for_update (avoids a circular prompt)."""
+        with (
+            patch("pcswitcher.cli._maybe_check_for_update") as mock_check,
+            patch("pcswitcher.cli._get_current_version_or_exit", return_value=SAME_RELEASE.version),
+            patch("pcswitcher.cli._resolve_target_version", return_value=SAME_RELEASE),
+        ):
+            result = runner.invoke(cli.app, ["self", "update"])
+
+        assert result.exit_code == 0, result.stdout
+        mock_check.assert_not_called()
+
+    def test_non_self_subcommand_invokes_version_check(self) -> None:
+        """Mirror assertion: a real subcommand (e.g. `logs`) DOES call _maybe_check_for_update."""
+        with (
+            patch("pcswitcher.cli._maybe_check_for_update") as mock_check,
+            patch("pcswitcher.cli.get_logs_directory", return_value=MagicMock(exists=lambda: False)),
+        ):
+            result = runner.invoke(cli.app, ["logs"])
+
+        assert result.exit_code == 0, result.stdout
+        mock_check.assert_called_once()

--- a/tests/unit/cli/test_version_check.py
+++ b/tests/unit/cli/test_version_check.py
@@ -176,6 +176,18 @@ class TestMaybeCheckForUpdateSkipConditions:
 
         mock_get_highest.assert_not_called()
 
+    def test_help_request_skips(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """`<cmd> --help` skips the check so help renders without blocking on the prompt (WR-01, #176)."""
+        console = _capture_console()
+        monkeypatch.setattr(cli.sys, "argv", ["pc-switcher", "sync", "--help"])
+        with (
+            patch("pcswitcher.cli.is_interactive", return_value=True),
+            patch("pcswitcher.cli.get_highest_release") as mock_get_highest,
+        ):
+            cli._maybe_check_for_update(console, no_version_check=False)  # pyright: ignore[reportPrivateUsage]
+
+        mock_get_highest.assert_not_called()
+
 
 class TestMaybeCheckForUpdateFailureFallbacks:
     """check raises; upgrade fails; execvp OSError - all warn and continue, never fatal."""
@@ -208,6 +220,23 @@ class TestMaybeCheckForUpdateFailureFallbacks:
             patch("pcswitcher.cli.subprocess.run", return_value=failed_install),
             patch("pcswitcher.cli.os.execvp") as mock_execvp,
         ):
+            cli._maybe_check_for_update(console, no_version_check=False)  # pyright: ignore[reportPrivateUsage]
+
+        mock_execvp.assert_not_called()
+        assert "warning" in console.file.getvalue().lower()  # pyright: ignore[reportAttributeAccessIssue]
+
+    def test_upgrade_oserror_warns_and_continues(self) -> None:
+        """`uv` missing from PATH makes subprocess.run raise OSError; must not crash startup (CR-01, #176)."""
+        console = _capture_console()
+        with (
+            patch("pcswitcher.cli.is_interactive", return_value=True),
+            patch("pcswitcher.cli.get_this_version", return_value=CURRENT_VERSION),
+            patch("pcswitcher.cli.get_highest_release", return_value=HIGHER_RELEASE),
+            patch("pcswitcher.cli.Prompt.ask", return_value="y"),
+            patch("pcswitcher.cli.subprocess.run", side_effect=FileNotFoundError("uv not found")),
+            patch("pcswitcher.cli.os.execvp") as mock_execvp,
+        ):
+            # Must return normally (never propagate) so the invoking command still runs.
             cli._maybe_check_for_update(console, no_version_check=False)  # pyright: ignore[reportPrivateUsage]
 
         mock_execvp.assert_not_called()
@@ -267,3 +296,21 @@ class TestMainCallbackWiring:
 
         assert result.exit_code == 0, result.stdout
         mock_check.assert_called_once()
+
+
+class TestSelfUpdateFailureModes:
+    """`self update` failure handling that the startup path shares (#176)."""
+
+    def test_uv_missing_shows_clean_error_not_traceback(self) -> None:
+        """A missing `uv` binary (OSError) yields a clean error + exit 1, not a raw traceback (WR-02, #176)."""
+        with (
+            patch("pcswitcher.cli._get_current_version_or_exit", return_value=CURRENT_VERSION),
+            patch("pcswitcher.cli._resolve_target_version", return_value=HIGHER_RELEASE),
+            patch("pcswitcher.cli.subprocess.run", side_effect=FileNotFoundError("uv not found")),
+        ):
+            result = runner.invoke(cli.app, ["self", "update"])
+
+        assert result.exit_code == 1
+        # Exited cleanly via sys.exit, not by letting the OSError escape as a traceback.
+        assert isinstance(result.exception, SystemExit)
+        assert "Could not run the upgrade" in result.stdout


### PR DESCRIPTION
Fixes #176

## Summary
Adds a best-effort startup version check to the pc-switcher CLI. On any real command, in an interactive terminal, if a newer **stable** GitHub release exists, it shows current-vs-available versions and offers to upgrade. On confirm it installs the release (reusing the existing `self update` install+verify path) and re-execs the same command line with the freshly installed binary.

### Behavior
- **Where:** app-level Typer callback → runs for every real subcommand. Skipped for `self` (avoids a circular prompt during manual `self update`), bare invocation, `--version`, and `--help`/`-h`.
- **Stable only:** compares against `get_highest_release(include_prereleases=False)`; prompts only when the latest stable is strictly newer than the running version.
- **On confirm:** install + verify, then `os.execvp(sys.argv[0], sys.argv)` with `PCSWITCHER_SKIP_VERSION_CHECK=1` set first so the re-exec'd process skips the check (no loop).
- **Skip conditions:** `--no-version-check` global flag, `PCSWITCHER_SKIP_VERSION_CHECK` env var, non-TTY (stdin or stdout), `self` subcommand, help requests.

### Failure handling — scoped to the on-disk mutation boundary
The "non-fatal, keep running your command" fallback applies **only before the installation is modified**. Once `uv tool install` runs, the current in-memory process is potentially stale — a later lazy import would load the new, possibly-incompatible module — so it must not keep executing:

- **Before disk is touched** (check fails / offline / rate-limited, user declines, or `uv` can't even be launched → nothing written): warn and continue the current command.
- **Upgrade ran but failed / verify failed** (disk may be modified): exit with a recovery hint (`pc-switcher self update`).
- **Upgrade succeeded but the automatic re-exec failed**: exit and ask the user to re-run (the new version is installed and verified; re-running picks it up).

This distinction is enforced by two exceptions out of the shared `_install_and_verify` helper: `UpgradeNotStartedError` (uv never ran, safe to continue) vs `UpdateFailedError` (uv ran, disk-touched, must not continue). `self update` retains its exit-on-failure behavior and exact user-facing strings (`Successfully updated`, `Already at version`).

## Test plan
- `uv run ruff format --check . && uv run ruff check . && uv run basedpyright` — clean.
- `uv run pytest tests/unit tests/contract` — 596 passed.
- `tests/unit/cli/test_version_check.py` (21 cases) covers: update-available → yes → upgrade + re-exec (guard env set); → no → continue; already-up-to-date / current-ahead → no prompt; non-TTY / `--no-version-check` / env-var / help / `self` → skip; and the scoped failure handling — uv-not-launchable → warn+continue, upgrade-failed-after-install → exit with recovery hint, re-exec-OSError → exit asking re-run, check-error → warn+continue. Every upgrade-path test patches `os.execvp`.
- Integration (`tests/integration/test_self_update.py`, VM-backed) runs in CI to confirm the preserved `self update` strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)