### PR TITLE
Fix flaky TUI render tests (poll instead of fixed sleep)

### DIFF
--- a/tests/unit/ui/test_terminal_ui.py
+++ b/tests/unit/ui/test_terminal_ui.py
@@ -29,6 +29,24 @@ from pcswitcher.models import ProgressUpdate
 from pcswitcher.ui import TerminalUI
 
 
+async def _wait_for_render(output: StringIO, needle: str, *, timeout: float = 2.0) -> str:
+    """Return the rendered buffer once `needle` appears, or after `timeout` seconds.
+
+    TerminalUI's setters store the new renderable and rely on Rich's 10 Hz
+    auto-refresh thread to draw it, so a fixed ``sleep(0.1)`` waits exactly one
+    refresh period and races under scheduling jitter. Poll on a short interval
+    with a generous deadline so the assertion is deterministic (and usually
+    faster than a fixed sleep on the happy path).
+    """
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    rendered = output.getvalue()
+    while needle not in rendered and loop.time() < deadline:
+        await asyncio.sleep(0.01)
+        rendered = output.getvalue()
+    return rendered
+
+
 async def test_core_us_tui_as1_progress_display() -> None:
     """Test CORE-US-TUI-AS1: Display progress bar, percentage, and job name.
 
@@ -191,11 +209,11 @@ async def test_set_total_steps_updates_total() -> None:
         ui.set_total_steps(20)
         assert ui._total_steps == 20, "set_total_steps should update _total_steps with live active"
 
-        # Allow the live display to flush the render to the output buffer
-        await asyncio.sleep(0.1)
-        rendered = output.getvalue()
+        # The step display shows "Step 5/20"; wait for the auto-refresh thread to
+        # draw it instead of sleeping exactly one refresh period (races).
+        rendered = await _wait_for_render(output, "Step 5/20")
 
-        # The step display shows "Step 5/20" — the updated total must appear
+        # The updated total must appear
         assert "20" in rendered, "Updated total from set_total_steps should appear in rendered output"
     finally:
         ui.stop()
@@ -211,16 +229,18 @@ async def test_set_current_step_renders_name() -> None:
     ui.start()
     try:
         ui.set_current_step(7, "Install on target")
-        await asyncio.sleep(0.1)
-        assert "Step 7/10" in output.getvalue()
-        assert "Install on target" in output.getvalue(), "step name must render next to the number"
+        rendered = await _wait_for_render(output, "Step 7/10")
+        assert "Step 7/10" in rendered
+        assert "Install on target" in rendered, "step name must render next to the number"
 
         # A subsequent step with no name clears the previous label.
         output.truncate(0)
         output.seek(0)
         ui.set_current_step(8)
-        await asyncio.sleep(0.1)
-        assert "Install on target" not in output.getvalue(), "omitting the name must clear the previous label"
+        # Wait for the redraw (Step 8/10) before asserting the old label is gone;
+        # otherwise the freshly truncated buffer trivially lacks it.
+        rendered = await _wait_for_render(output, "Step 8/10")
+        assert "Install on target" not in rendered, "omitting the name must clear the previous label"
     finally:
         ui.stop()
 


### PR DESCRIPTION
## Summary
Several `test_terminal_ui.py` render tests (e.g. `test_set_current_step_renders_name`, `AssertionError` on `Step 7/10`) fail after main's `rich` 14 → 15 bump. Root cause is a test-timing assumption, not a product bug.

`set_current_step` / `set_total_steps` (`src/pcswitcher/ui.py`) store the new renderable via `self._live.update(self._render())` *without* `refresh=True`, so the actual draw to the output buffer happens on Rich's background 10 Hz auto-refresh thread. The tests waited exactly one refresh period (`await asyncio.sleep(0.1)`) before asserting on the rendered output — zero timing margin.

Under rich 14 the first content frame landed within that 0.1 s window and the tests passed. Rich 15 shifted Live's first paint later (it now lands at ~0.2 s in local runs), so the assertion at the 0.1 s boundary runs *before* the frame exists. The result is a **deterministic failure on rich 15** (observed 8/8 with `-p no:randomly`), not an intermittent flake — the zero-margin sleep simply always loses now.

## Fix
Replace the zero-margin `sleep(0.1)` + assert spots with a `_wait_for_render()` helper that polls the buffer every 10 ms up to a 2 s deadline, catching the auto-refresh paint whenever it lands. Deterministic, and typically *faster* than the fixed sleep on the happy path.

For the label-clear assertion, the poll waits for the **positive** redraw marker (`Step 8/10`) before checking the old label is gone — otherwise the freshly `truncate()`d empty buffer would satisfy the negative assertion trivially, without proving the redraw happened.

No product code changed. The 10 Hz auto-refresh is correct for a live terminal (the progress bar has animated elements that need periodic repaint regardless), and `resume()` already forces `refresh=True` where immediate paint is genuinely required for cursor positioning. Fixing the tests' timing assumption is the right layer. The 0.2 / 0.3 s waits elsewhere in the file have 2–3× margin and were left as-is.

## Test plan
- `ruff check` / `ruff format --check` / `basedpyright` on the file — clean.
- The previously-failing tests run cleanly on rich 15 (~0.23 s each), and 30× with 0 failures.
- Full `tests/unit` suite green across multiple random-seed orderings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
