### PR TITLE
Strict, context-aware SSH host-key check in run-integration-tests (#87)

### DIFF
--- a/docs/ops/testing-architecture.md
+++ b/docs/ops/testing-architecture.md
@@ -440,6 +440,15 @@ The infrastructure scripts use proper SSH host key verification. For each host, 
 | `configure-vm.sh` | `ssh_run` only | Key established by create-vm.sh |
 | `configure-hosts.sh` | `ssh_run` only | Key established |
 | `reset-vm.sh` | `ssh_accept_new` | First from test runner |
+| `run-integration-tests.sh` | `ssh_verified` (strict) | Readiness check; VMs already provisioned |
+
+The provisioning scripts above may legitimately encounter new or changed host keys (fresh VMs, reprovisioning), so they use `accept-new`. By the time `run-integration-tests.sh` runs its VM-readiness check, the VMs are already provisioned and their keys should already be trusted — so `check_vm_ready` uses `ssh_verified`, which **never** auto-accepts a new key. Its host-key policy depends on the execution context (`ssh_exec_context` in `common.sh`):
+
+| Context | Detection | Host-key policy |
+|---------|-----------|-----------------|
+| CI | `CI_JOB_ID` / `GITHUB_RUN_ID` set | `StrictHostKeyChecking=yes` + `BatchMode=yes`. known_hosts is pre-populated by the workflow (`ssh-keyscan`); a new or changed key is a hard failure. |
+| Non-interactive agent | `CLAUDECODE=1` | Same strict + batch policy. No TTY to prompt on, so an unknown key fails fast with an explicit, actionable error. |
+| Interactive developer | neither of the above | Default ssh (`StrictHostKeyChecking=ask`); prompts to accept an unknown key. |
 
 ## Session-Scoped Fixtures
 

--- a/tests/integration/scripts/internal/common.sh
+++ b/tests/integration/scripts/internal/common.sh
@@ -172,6 +172,49 @@ ssh_accept_new() {
     ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=accept-new -o BatchMode=yes "$@"
 }
 
+# Report the execution context, controlling how strictly host keys are checked.
+# Detection mirrors the lock-holder logic in _generate_lock_holder.
+#
+# Echoes one of:
+#   ci          - CI job (CI_JOB_ID or GITHUB_RUN_ID set); known_hosts is
+#                 pre-populated by the workflow.
+#   claude      - non-interactive agent run (CLAUDECODE=1); no TTY to prompt on.
+#   interactive - a developer at a terminal.
+ssh_exec_context() {
+    if [[ -n "${CI_JOB_ID:-${GITHUB_RUN_ID:-}}" ]]; then
+        echo "ci"
+    elif [[ "${CLAUDECODE:-}" == "1" ]]; then
+        echo "claude"
+    else
+        echo "interactive"
+    fi
+}
+
+# Strict, context-aware SSH that never auto-accepts a new or changed host key.
+# Use for connections to already-provisioned hosts whose keys should already be
+# trusted (unlike ssh_first/ssh_accept_new, which are for provisioning).
+#
+# Host-key policy by execution context (see ssh_exec_context):
+#   ci, claude  - StrictHostKeyChecking=yes + BatchMode=yes. An unknown or
+#                 changed key is a hard failure (exit 255): CI pre-populates
+#                 known_hosts, and claude has no TTY to prompt on.
+#   interactive - default ssh (StrictHostKeyChecking=ask); prompts the developer
+#                 to accept an unknown key. stderr is left attached so the
+#                 prompt is visible — do NOT redirect it away at the call site.
+#
+# Usage: ssh_verified <user@host> [ssh args...]
+# Example: ssh_verified testuser@192.168.1.100 "echo hello"
+ssh_verified() {
+    case "$(ssh_exec_context)" in
+        ci | claude)
+            ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=yes -o BatchMode=yes "$@"
+            ;;
+        *)
+            ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=ask "$@"
+            ;;
+    esac
+}
+
 # Subsequent connections: normal SSH (verifies stored key)
 # Use after key has been established by wait_for_ssh, ssh_first, or ssh_accept_new.
 # Fails if host key is not in known_hosts or doesn't match.

--- a/tests/run-integration-tests.sh
+++ b/tests/run-integration-tests.sh
@@ -198,24 +198,43 @@ check_vm_ready() {
     local vm_host="$1"
     local user="$2"
 
-    # Try to connect and check baseline snapshot exists
-    ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=accept-new -o BatchMode=yes \
-        "${user}@${vm_host}" \
-        "sudo btrfs subvolume show /.snapshots/baseline/@ >/dev/null 2>&1" 2>/dev/null
+    # Try to connect and check baseline snapshot exists. ssh_verified never
+    # auto-accepts a new/changed host key: by this point the VM is provisioned
+    # and its key should already be trusted, so an unexpected key is an error,
+    # not something to silently accept. (Behavior varies by execution context —
+    # see ssh_verified / ssh_exec_context in common.sh.) The remote command
+    # silences its own output; ssh's stderr is left attached so an interactive
+    # host-key prompt stays visible.
+    ssh_verified "${user}@${vm_host}" \
+        "sudo btrfs subvolume show /.snapshots/baseline/@ >/dev/null 2>&1"
     local exit_code=$?
 
     if [[ $exit_code -eq 0 ]]; then
         return 0
     fi
 
-    # Exit 255 = SSH transport failure (unreachable, timeout, or a rejected host
-    # key). accept-new auto-trusts a *new* key but refuses a *changed* one, so a
-    # stale known_hosts entry lands here rather than in the "not provisioned" path.
+    # Exit 255 = SSH transport failure: unreachable, timeout, or a rejected host
+    # key. Strict checking refuses a new/changed key rather than trusting it, so
+    # a stale known_hosts entry lands here rather than in the "not provisioned"
+    # path. Tailor the guidance to the execution context.
     if [[ $exit_code -eq 255 ]]; then
-        log_error "SSH connection to ${vm_host} failed (could not run remote command)."
-        log_error "The VM may be unreachable, or its host key in ~/.ssh/known_hosts is stale."
-        log_error "Diagnose with: ssh ${user}@${vm_host} 'echo ok'"
-        log_error "If the key changed, refresh it: ssh-keygen -R ${vm_host}"
+        case "$(ssh_exec_context)" in
+            claude)
+                log_error "SSH to ${vm_host} failed. Host keys are not accepted automatically here (running non-interactively as claude)."
+                log_error "If the VM's key is new or changed, verify it out-of-band, then trust it:"
+                log_error "  ssh-keygen -R ${vm_host} && ssh-keyscan -H ${vm_host} >> ~/.ssh/known_hosts"
+                ;;
+            ci)
+                log_error "SSH to ${vm_host} failed. In CI, host keys must already be in known_hosts (populated by the workflow); new or changed keys are rejected."
+                log_error "The VM may be unreachable, or its key changed since known_hosts was set up."
+                ;;
+            *)
+                log_error "SSH connection to ${vm_host} failed."
+                log_error "The VM may be unreachable, or you declined its host key at the prompt."
+                log_error "Diagnose with: ssh ${user}@${vm_host} 'echo ok'"
+                log_error "If the key changed, refresh it: ssh-keygen -R ${vm_host}"
+                ;;
+        esac
     fi
     return 1
 }


### PR DESCRIPTION
Fixes #87

## Summary
`check_vm_ready` in `run-integration-tests.sh` used `StrictHostKeyChecking=accept-new`, silently trusting new host keys in every mode. By the time the test runner probes the VMs they are already provisioned and their keys should already be in `known_hosts`, so a new/changed key is an error — not something to auto-accept.

New helpers in `tests/integration/scripts/internal/common.sh` centralize the policy:

- `ssh_exec_context` — reports `ci` / `claude` / `interactive` (detection mirrors the lock-holder logic: `CI_JOB_ID`/`GITHUB_RUN_ID`, then `CLAUDECODE=1`).
- `ssh_verified` — strict SSH that never auto-accepts a key:
  - **CI / claude**: `StrictHostKeyChecking=yes` + `BatchMode=yes` → unknown/changed key is a hard failure (exit 255).
  - **interactive**: default ssh (`StrictHostKeyChecking=ask`) → prompts the developer.

`check_vm_ready` now calls `ssh_verified` and tailors its exit-255 error guidance per context (claude gets an explicit "keys not accepted automatically here" message with the exact `ssh-keygen -R` / `ssh-keyscan` commands).

Maps to the four issue requirements: CI strict ✓, local interactive prompt ✓, local non-interactive explicit error ✓, reuse of common.sh helpers ✓.

Provisioning scripts (`ssh_first`/`ssh_accept_new`) are unchanged — they legitimately meet fresh/changed keys and still use `accept-new`.

## Test plan
- `bash -n` on both scripts: pass.
- shellcheck (via `uvx shellcheck-py`) on both scripts: no new findings from the added code (only pre-existing warnings remain).
- `uv run ruff format --check .`, `uv run ruff check .`, `uv run basedpyright`: clean.
- `uv run pytest`: 626 passed.
- Integration CI (this workflow) exercises the CI path end-to-end — run once out of draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0182ghJADVideUogjAozruxP