### PR TITLE
fix(folder_sync): mirror pc-switcher install so it can't desync from its interpreter

### DIFF
--- a/docs/adr/_index.md
+++ b/docs/adr/_index.md
@@ -1,4 +1,4 @@
-# Architecture Decisions Summary (Last updated: 2026-07-03)
+# Architecture Decisions Summary (Last updated: 2026-07-20)
 
 ## Active Decisions
 
@@ -17,14 +17,11 @@
 - [ADR-013](adr-013-rsync-over-ssh-user-data-transport.md): rsync-over-SSH as user-data transport, running as root via sudo
 - [ADR-014](adr-014-unified-dry-run-contract.md): Unified dry-run contract for all SyncJobs
 - [ADR-015](adr-015-topology-based-sync-safety-model.md): Topology-based sync-safety model (btrfs find-new content-detection removed)
-- [ADR-016](adr-016-hardcoded-runtime-file-excludes.md): Hardcoded exclusion of pc-switcher's own runtime files from folder sync
+- [ADR-017](adr-017-mirror-pcswitcher-install.md): Mirror pc-switcher's own install; hardcode-exclude only its runtime state
 
 ### Instructions for AI agents
 Load specific ADRs only when relevant to current task: search workspace files to find relevant ADRs
 
 ## Superseded
 
-(None)
-
-Example:
-- ADR-005: Direct IBKR Gateway → Superseded by ADR-017
+- [ADR-016](adr-016-hardcoded-runtime-file-excludes.md): Hardcoded exclusion of pc-switcher's own runtime files → Superseded by [ADR-017](adr-017-mirror-pcswitcher-install.md)

--- a/docs/adr/adr-016-hardcoded-runtime-file-excludes.md
+++ b/docs/adr/adr-016-hardcoded-runtime-file-excludes.md
@@ -1,8 +1,10 @@
 # ADR-016: Hardcoded exclusion of pc-switcher's own runtime files from folder sync
 
-Status: Accepted
+Status: Superseded by ADR-017
 
 Date: 2026-07-03
+
+Superseded by: [ADR-017](adr-017-mirror-pcswitcher-install.md) — the install (uv tool venv + shim) is no longer excluded; only the runtime-state directory stays hardcoded-excluded. Excluding the venv while `--delete`-mirroring its interpreter tree deleted the in-use interpreter and broke pc-switcher on the target (#185).
 
 ## TL;DR
 Folder sync always excludes pc-switcher's own runtime state, install, and logs; these are the only hardcoded excludes — every other exclusion stays user-configurable.

--- a/docs/adr/adr-017-mirror-pcswitcher-install.md
+++ b/docs/adr/adr-017-mirror-pcswitcher-install.md
@@ -1,0 +1,42 @@
+# ADR-017: Mirror pc-switcher's own install; hardcode-exclude only its runtime state
+
+Status: Accepted
+
+Date: 2026-07-20
+
+Supersedes: ADR-016
+
+## TL;DR
+Folder sync mirrors pc-switcher's own install (uv tool venv + `~/.local/bin` shim) like any other file; only its runtime *state* directory stays hardcoded-excluded, so the install and the interpreter it depends on always travel together.
+
+## Implementation Rules
+- `FolderSyncJob` MUST hardcode-exclude exactly one path, the invoking user's `.local/share/pc-switcher/` (lock file, `sync-history.json`, logs), regardless of user config. This is the ONLY hardcoded exclude.
+- The pc-switcher install MUST NOT be excluded: `.local/share/uv/tools/pcswitcher/` (the venv) and `.local/bin/pc-switcher` (the shim) mirror from source like every other uv tool, alongside the uv interpreter tree under `.local/share/uv/python/`.
+- The hardcoded exclude MUST anchor relative to the invoking user's home and only apply when that home is inside the synced folder; it MUST precede user filter rules so no `+` rule can re-expose it (unchanged from ADR-016).
+- `validate()` MUST abort the sync on a source/target CPU-architecture mismatch (`uname -m`), since the mirrored venv and interpreter are arch-specific binaries.
+
+## Context
+ADR-016 hardcode-excluded the pc-switcher install (venv + shim) from the `/home` mirror to keep the "running install" machine-local. But the uv *interpreter* tree (`.local/share/uv/python/`) was not excluded, so it was `--delete`-mirrored to match the source. uv interpreters diverge per machine by patch version, so the frozen venv referenced an interpreter that existed only on the target — and the mirror deleted it, leaving a dangling shebang and a pc-switcher that could not execute on the target (#185). Nothing runs pc-switcher on the target during a sync except the install-on-target step, so the install does not need to be pinned machine-local; it only needs to stay internally consistent with its interpreter.
+
+## Decision
+- Hardcode-exclude only `.local/share/pc-switcher/` (runtime state); drop the venv and shim from the exclude set.
+- Let the install mirror from source with its interpreter in the same pass, so both come from the source and stay consistent — the same way every other uv tool already syncs.
+- Guard the new arch coupling with a `uname -m` source-vs-target check in `validate()` that aborts on mismatch.
+- Keep the install-on-target step: it provisions a working pc-switcher on the target before the folder-sync step (relevant to #126), and its output being overwritten by the mirror is harmless.
+
+## Consequences
+**Positive**:
+- pc-switcher's install and its interpreter can no longer desync; the #185 dangling-interpreter failure is structurally impossible.
+- Uniform handling: pc-switcher is no longer a special-cased uv tool.
+- The topology-safety state, lock, and logs (ADR-015) stay machine-local, as before.
+
+**Negative**:
+- The fleet must be single-architecture; the arch check turns an unsupported heterogeneous fleet into an explicit preflight abort rather than a cryptic exec failure.
+- The target's pc-switcher install is overwritten by the source's on every sync (source wins); there is no downgrade guard on the mirrored install.
+
+## References
+- ADR-016: Hardcoded exclusion of pc-switcher's own runtime files (superseded by this ADR)
+- ADR-015: Topology-based sync-safety model
+- ADR-013: rsync-over-SSH as user-data transport
+- Issue #185 (root cause and fix); issue #126 (why install-on-target is retained)
+- `src/pcswitcher/jobs/folder_sync.py` (`_RUNTIME_EXCLUDE_RELPATHS`, `validate()` arch check)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -209,4 +209,4 @@ Otherwise it matches gitignore (basenames, a trailing `/` for directories, `*`/`
 
 ### Always excluded
 
-pc-switcher's own files are always excluded and cannot be re-included, so a sync never disturbs the target's sync state or the running install: `~/.local/share/pc-switcher/`, `~/.local/share/uv/tools/pcswitcher`, and `~/.local/bin/pc-switcher`.
+pc-switcher's own runtime state — `~/.local/share/pc-switcher/` (lock file, sync history, logs) — is always excluded and cannot be re-included, so a sync never disturbs the target's sync state or per-machine logs. This is the only hardcoded exclude; pc-switcher's install itself (its uv tool venv and `~/.local/bin` shim) mirrors like any other file, so it stays consistent with the interpreter it depends on (ADR-017).

--- a/src/pcswitcher/jobs/folder_sync.py
+++ b/src/pcswitcher/jobs/folder_sync.py
@@ -37,17 +37,18 @@ from pcswitcher.models import FirstSyncScope, Host, LogLevel, ProgressUpdate, Va
 # Group 2: percent complete.  Group 3: files transferred so far.  Group 4: total-to-check.
 _PROGRESS2_RE = re.compile(r"(\d+[\d,.]*[KMGT]?)\s+(\d+)%\s+\S+\s+\S+\s+\(xfr#(\d+),\s*to-chk=\d+/(\d+)\)")
 
-# pc-switcher's own runtime state and installation live under the invoking
-# user's home directory. Mirroring them between machines is unsafe:
-# sync-history.json is the topology-safety state (ADR-015) and a --delete mirror
-# would clobber the target's copy mid-sync; the lock file, logs, and the running
-# install must stay machine-local. These paths are ALWAYS excluded from folder
-# sync regardless of user config, and are the ONLY hardcoded excludes — every
-# other exclusion is user-configurable (ADR-016).
+# pc-switcher's own runtime STATE lives under the invoking user's home and must
+# stay machine-local: sync-history.json is the topology-safety state (ADR-015) that
+# a --delete mirror would clobber mid-sync; the lock file and logs are per-machine.
+# This is the ONLY hardcoded exclude — every other exclusion is user-configurable.
+#
+# The install itself (uv tool venv + ~/.local/bin shim) is deliberately NOT
+# excluded: it mirrors from source like any other uv tool, so the venv and the
+# interpreter it references travel together and stay consistent. Excluding the venv
+# while --delete-mirroring the uv interpreter tree it depends on deleted the in-use
+# interpreter and broke pc-switcher on the target. See ADR-017 (supersedes ADR-016).
 _RUNTIME_EXCLUDE_RELPATHS: tuple[str, ...] = (
     ".local/share/pc-switcher",  # lock, sync-history.json, logs/
-    ".local/share/uv/tools/pcswitcher",  # uv tool install (virtualenv)
-    ".local/bin/pc-switcher",  # entry-point shim
 )
 
 
@@ -193,10 +194,31 @@ class FolderSyncJob(SyncJob):
            `filter_file`, its (expanded) path must also exist on the source, else
            a configured-but-absent filter file could silently degrade to a full
            `--delete` mirror with no filter rules applied.
+        4. Source and target share the same CPU architecture (`uname -m`): the
+           pc-switcher install mirrors as arch-specific binaries (ADR-017), so a
+           heterogeneous fleet is unsupported.
 
         Returns the list of validation errors (empty on success).
         """
         errors: list[ValidationError] = []
+
+        # --- Step 0: source/target CPU architecture match ---
+        # The pc-switcher install (uv tool venv + interpreter) mirrors to the target
+        # as arch-specific binaries (ADR-017). A heterogeneous fleet would ship a
+        # wrong-arch interpreter that dies at exec time with a cryptic
+        # "cannot execute: required file not found"; refuse it up front. Fail open if
+        # either `uname -m` cannot be read (never determined arch → nothing to compare).
+        src_arch = await self.source.run_command("uname -m")
+        tgt_arch = await self.target.run_command("uname -m", login_shell=False)
+        if src_arch.success and tgt_arch.success and src_arch.stdout.strip() != tgt_arch.stdout.strip():
+            errors.append(
+                self._validation_error(
+                    Host.TARGET,
+                    f"source/target CPU architecture mismatch "
+                    f"({src_arch.stdout.strip()} vs {tgt_arch.stdout.strip()}): pc-switcher mirrors "
+                    f"arch-specific binaries and does not support a heterogeneous fleet",
+                )
+            )
 
         # --- Step 1: sudo rsync availability ---
         result = await self.source.run_command("sudo rsync --version")

--- a/tests/unit/jobs/test_folder_sync.py
+++ b/tests/unit/jobs/test_folder_sync.py
@@ -37,6 +37,17 @@ def fail_when(substring: str, stderr: str) -> Callable[..., CommandResult]:
     return _side_effect
 
 
+def arch_reports(machine: str) -> Callable[..., CommandResult]:
+    """Return a run_command side_effect that reports `machine` for `uname -m`, success otherwise."""
+
+    def _side_effect(cmd: str, **_: object) -> CommandResult:
+        if "uname -m" in cmd:
+            return CommandResult(exit_code=0, stdout=machine, stderr="")
+        return CommandResult(exit_code=0, stdout="", stderr="")
+
+    return _side_effect
+
+
 def make_context(
     config: dict[str, Any] | None = None,
     dry_run: bool = False,
@@ -185,12 +196,30 @@ class TestDescribeFirstSyncScope:
 
 @pytest.mark.asyncio
 class TestValidatePreflight:
-    """validate() enforces sudo rsync availability, acl package, and folder existence."""
+    """validate() enforces CPU-arch match, sudo rsync availability, acl package, and folder existence."""
 
     async def test_all_preflight_checks_pass(self) -> None:
         """When all preflight commands succeed, validate() returns no errors."""
         ctx = make_context(config={"folders": [{"path": "/home"}]})
         # source and target run_command already return success by default
+        job = FolderSyncJob(ctx)
+        errors = await job.validate()
+        assert errors == []
+
+    async def test_arch_mismatch_between_source_and_target(self) -> None:
+        """Differing CPU architecture on source vs target is a validation error."""
+        ctx = make_context(config={"folders": [{"path": "/home"}]})
+        ctx.source.run_command = AsyncMock(side_effect=arch_reports("x86_64"))
+        ctx.target.run_command = AsyncMock(side_effect=arch_reports("aarch64"))
+        job = FolderSyncJob(ctx)
+        errors = await job.validate()
+        assert any(e.host == Host.TARGET and "architecture" in e.message.lower() for e in errors)
+
+    async def test_matching_arch_yields_no_error(self) -> None:
+        """Identical CPU architecture on both hosts yields no validation error."""
+        ctx = make_context(config={"folders": [{"path": "/home"}]})
+        ctx.source.run_command = AsyncMock(side_effect=arch_reports("x86_64"))
+        ctx.target.run_command = AsyncMock(side_effect=arch_reports("x86_64"))
         job = FolderSyncJob(ctx)
         errors = await job.validate()
         assert errors == []
@@ -507,11 +536,7 @@ class TestRuntimeExcludeFilters:
     home and only apply when that home is inside the synced folder.
     """
 
-    _RELPATHS = (
-        ".local/share/pc-switcher",
-        ".local/share/uv/tools/pcswitcher",
-        ".local/bin/pc-switcher",
-    )
+    _RELPATHS = (".local/share/pc-switcher",)
 
     def _filters(self, folder_path: str, home: str) -> list[str]:
         with patch("pcswitcher.jobs.folder_sync.Path.home", return_value=Path(home)):


### PR DESCRIPTION
Fixes #185.

## Problem

After a successful sync, `pc-switcher` on the target failed with `cannot execute: required file not found` — a dangling shebang. The pcswitcher uv tool venv was hardcoded-excluded from the `/home` mirror (frozen), but the uv interpreter tree (`.local/share/uv/python/`) was `--delete`-mirrored to match the source. uv interpreters diverge per machine by patch version, so the frozen venv pointed at an interpreter present only on the target; the mirror deleted it. See #185 for the full analysis.

## Change

- Stop hardcode-excluding the install: `.local/share/uv/tools/pcswitcher` (venv) and `.local/bin/pc-switcher` (shim) now mirror from source alongside the interpreter, like every other uv tool, so both stay consistent.
- Only `.local/share/pc-switcher` (lock / sync-history / logs) stays hardcoded-excluded — genuinely machine-local state (ADR-015).
- `validate()` aborts on a source/target `uname -m` mismatch, since the mirrored venv + interpreter are arch-specific.
- `install_on_target` is deliberately kept as the #126 hedge (nothing runs pc-switcher on the target during a sync except that step; its output being overwritten by the mirror is harmless).
- Supersede ADR-016 with ADR-017; update `configuration.md`.

## Testing

- `uv run pytest` — 628 passed. New unit tests cover the arch-mismatch abort and the matching-arch pass; the runtime-exclude tests now assert the single remaining exclude.
- `uv run ruff check/format` and `uv run basedpyright` — clean.
- Integration tests run in CI (draft PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JqyQiMuqNscPCrLAXxtRA7
