### PR TITLE
fix(topology): resolve target hostname symmetrically and compare case-insensitively

### DIFF
--- a/docs/adr/adr-015-topology-based-sync-safety-model.md
+++ b/docs/adr/adr-015-topology-based-sync-safety-model.md
@@ -71,6 +71,15 @@ Decisions:
 
 This supersedes the Consequences note "first-ever sync … treat absent history as in-order": absent history is now handled by the first-sync confirmation, not silently treated as in-order.
 
+## Refinement: peer hostnames are acquired symmetrically and compared case-insensitively
+
+This section refines the Decision above; where they differ, this section takes precedence.
+
+The topology check compares recorded `last_peer` values against the machines involved. For that comparison to be reliable, both peers must name the same machine the same way. Two rules make this hold:
+
+- Both ends record a machine's *own* hostname. The source records its peer as the target's `socket.gethostname()` queried over SSH (not the user-typed CLI argument, which may be an SSH alias or IP), the same way the source obtains its own hostname locally. This keeps the SSH/rsync connection address (the CLI argument) separate from the recorded identity.
+- Peer comparisons are case-insensitive. DNS hostnames are case-insensitive, and history written before symmetric acquisition (or via a differently-cased alias) can hold either casing. Matching case-folded prevents a clean back-sync from being misread as a machine-C (W2) sync — e.g. a target that recorded its peer as `fleksi` still matches a source whose hostname is `Fleksi`.
+
 ## References
 
 - ADR-013: rsync-over-SSH as user-data transport (transport layer this safety model sits above)

--- a/docs/system/architecture.md
+++ b/docs/system/architecture.md
@@ -27,8 +27,9 @@ This document describes the architecture for the pc-switcher system, covering th
 | **hostname** | `str` | e.g., `"laptop-work"` | The actual machine name |
 
 **Resolution:**
-- Source hostname: obtained from local machine (e.g., `socket.gethostname()`)
-- Target hostname: provided via CLI argument `sync <target>`, resolved from SSH config if alias
+- Source hostname: obtained from local machine (`socket.gethostname()`)
+- Target connection address: the CLI argument `sync <target>` (hostname, SSH alias, or IP), used as the SSH/rsync destination
+- Target hostname for sync-history and the topology check: the target's own `socket.gethostname()`, queried over SSH so both ends are acquired the same way. Peers are compared case-insensitively, so a differently-cased or aliased target still matches a clean back-sync (ADR-015)
 
 ---
 

--- a/src/pcswitcher/lock.py
+++ b/src/pcswitcher/lock.py
@@ -180,3 +180,17 @@ def get_local_hostname() -> str:
         Hostname string
     """
     return socket.gethostname()
+
+
+def get_hostname_command() -> str:
+    """Shell command that prints the executing machine's hostname.
+
+    Yields the same value `get_local_hostname()` produces locally — both derive
+    from ``socket.gethostname()`` — so a machine's hostname is obtained identically
+    whether it is the source (local call) or the target (this command over SSH).
+    That symmetry is what lets the topology check compare like-for-like instead of
+    matching a real hostname against a user-typed CLI argument (see ADR-015).
+
+    Requires python3 on the remote (guaranteed on Ubuntu 24.04 targets).
+    """
+    return 'python3 -c "import socket; print(socket.gethostname())"'

--- a/src/pcswitcher/orchestrator.py
+++ b/src/pcswitcher/orchestrator.py
@@ -29,6 +29,7 @@ from pcswitcher.jobs.disk_space_monitor import DiskSpaceMonitorJob
 from pcswitcher.jobs.install_on_target import InstallOnTargetJob
 from pcswitcher.lock import (
     SyncLock,
+    get_hostname_command,
     get_local_hostname,
     get_lock_path,
     release_remote_lock,
@@ -57,6 +58,7 @@ from pcswitcher.sync_history import (
     SyncRole,
     get_last_sync_state,
     get_record_role_command,
+    hostnames_equal,
     parse_sync_state,
     record_role,
 )
@@ -179,7 +181,14 @@ class Orchestrator:
         self._session_id = secrets.token_hex(4)
         self._session_folder = session_folder_name(self._session_id)
         self._source_hostname = get_local_hostname()
+        # SSH-connectable target: the raw CLI argument (hostname, SSH alias, or IP).
+        # Load-bearing as the rsync/SSH destination — never overwrite with a resolved name.
         self._target_hostname = target
+        # Target's own hostname, resolved over SSH the same way the source resolves its
+        # own (socket.gethostname()), so sync-history peers and the topology check compare
+        # like-for-like instead of matching a real hostname against a typed CLI argument.
+        # Falls back to the CLI argument until _establish_connection resolves it.
+        self._target_canonical_hostname = target
 
         # Core components
         self._event_bus = EventBus()
@@ -458,6 +467,36 @@ class Orchestrator:
 
         self._logger.info("Connected to target", extra={"job": "orchestrator", "host": "target"})
 
+        await self._resolve_target_canonical_hostname()
+
+    async def _resolve_target_canonical_hostname(self) -> None:
+        """Resolve the target's own hostname over SSH (source-symmetric acquisition).
+
+        The source records its peer using `get_local_hostname()`; without this the
+        target would be recorded under the user-typed CLI argument instead, so the
+        two ends store the same machine under different names (e.g. `p17` vs `P17`)
+        and the topology check misreads a clean back-sync as a foreign one. On any
+        failure (non-zero exit, empty output) the CLI-argument fallback set in
+        __init__ is kept — a resolved hostname is a refinement, not a hard gate.
+        """
+        assert self._remote_executor is not None
+
+        result = await self._remote_executor.run_command(get_hostname_command())
+        resolved = result.stdout.strip() if result.success else ""
+        if resolved:
+            self._target_canonical_hostname = resolved
+            self._logger.debug(
+                "Resolved target hostname: %s",
+                resolved,
+                extra={"job": "orchestrator", "host": "target"},
+            )
+        else:
+            self._logger.debug(
+                "Could not resolve target hostname; using CLI argument %r",
+                self._target_hostname,
+                extra={"job": "orchestrator", "host": "target"},
+            )
+
     async def _acquire_target_lock(self) -> None:
         """Acquire exclusive lock on target machine via SSH.
 
@@ -680,7 +719,9 @@ class Orchestrator:
         assert self._confirmer is not None
 
         src = self._source_hostname
-        tgt = self._target_hostname
+        # Compare against the target's resolved own hostname, not the CLI argument, so
+        # a differently-cased or aliased target still matches recorded peers.
+        tgt = self._target_canonical_hostname
 
         # Read local sync state (role + peer from this machine's sync-history.json)
         local_role, local_peer = get_last_sync_state()
@@ -705,15 +746,15 @@ class Orchestrator:
             return True
 
         # Consecutive push: this source most recently synced TO this same target
-        consecutive_push = local_role == SyncRole.SOURCE and local_peer == tgt
+        consecutive_push = local_role == SyncRole.SOURCE and hostnames_equal(local_peer, tgt)
 
         # Suppress (clean case): target last synced with this source, and this is
         # not a repeat push from the same source without a back-sync.
-        if target_peer == src and not consecutive_push:
+        if hostnames_equal(target_peer, src) and not consecutive_push:
             return True
 
         # Determine warning type and compose message
-        if target_peer is not None and target_peer != src:
+        if target_peer is not None and not hostnames_equal(target_peer, src):
             # W2: machine-C — target last synced with a third machine
             direction = "received a sync from" if target_role == SyncRole.TARGET else "sent a sync to"
             warn_title = "Target Last Synced with a Different Machine"
@@ -759,15 +800,17 @@ class Orchestrator:
         - Source machine's history: last_role = SOURCE, last_peer = target hostname
         - Target machine's history: last_role = TARGET, last_peer = source hostname
 
-        Recording `last_peer` on both ends enables the topology out-of-order check
-        to distinguish the clean A→B / B→A pattern from the machine-C and
-        consecutive-push cases on the next sync.
+        Both peers are the machines' own resolved hostnames (target via SSH, source
+        via `get_local_hostname()`), never the user-typed CLI argument, so the next
+        sync's topology check compares like-for-like. Recording `last_peer` on both
+        ends lets that check distinguish the clean A→B / B→A pattern from the
+        machine-C and consecutive-push cases.
 
         Raises:
             RuntimeError: If history update fails on either machine.
         """
         # Update local (source) history
-        record_role(SyncRole.SOURCE, peer=self._target_hostname)
+        record_role(SyncRole.SOURCE, peer=self._target_canonical_hostname)
         self._logger.debug("Updated sync history: role=source", extra={"job": "orchestrator", "host": "source"})
 
         # Update remote (target) history via SSH

--- a/src/pcswitcher/sync_history.py
+++ b/src/pcswitcher/sync_history.py
@@ -34,6 +34,7 @@ __all__ = [
     "get_last_role_with_error",
     "get_last_sync_state",
     "get_record_role_command",
+    "hostnames_equal",
     "parse_sync_state",
     "record_role",
 ]
@@ -209,6 +210,23 @@ def get_record_role_command(role: SyncRole, peer: str | None = None) -> str:
     )
     script = "\n".join(lines)
     return f'mkdir -p {HISTORY_DIR} && python3 -c "{script}"'
+
+
+def hostnames_equal(a: str | None, b: str | None) -> bool:
+    """Compare two hostnames case-insensitively for the topology safety checks.
+
+    DNS hostnames are case-insensitive, so `P17` and `p17` denote the same machine.
+    History recorded before hostnames were acquired uniformly (or a target reached
+    via a differently-cased SSH alias) can hold either casing; matching case-folded
+    prevents a spurious "synced with a different machine" warning on a clean
+    back-sync.
+
+    A ``None`` peer never matches — including another ``None`` — because an absent
+    peer is not evidence that the topology is clean.
+    """
+    if a is None or b is None:
+        return False
+    return a.casefold() == b.casefold()
 
 
 def parse_sync_state(content: str) -> tuple[SyncRole | None, str | None]:

--- a/tests/unit/orchestrator/test_consecutive_sync.py
+++ b/tests/unit/orchestrator/test_consecutive_sync.py
@@ -659,6 +659,125 @@ class TestCheckOutOfOrderDryRun:
 # ---------------------------------------------------------------------------
 
 
+class TestCheckOutOfOrderHostnameCasing:
+    """A clean back-sync must be recognised regardless of hostname casing.
+
+    Regression for the spurious "Target Last Synced with a Different Machine"
+    warning: the target recorded this machine's peer under a differently-cased
+    name (e.g. the user typed `sync fleksi` on the target, so it stored `fleksi`,
+    while this machine's own hostname is `Fleksi`). The topology comparison is
+    case-insensitive, so the clean A→B / B→A pattern still proceeds silently.
+    """
+
+    @pytest.mark.asyncio
+    async def test_case_mismatched_back_sync_is_clean(
+        self,
+        mock_config: MagicMock,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """target_peer differs from source only in case → suppressed, no prompt."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        # This machine's real hostname (capitalised).
+        source_name = "Fleksi"
+        target_name = "p17"
+
+        # Local: this machine last synced as TARGET, peer recorded as the target's
+        # own hostname "P17" (capitalised) — differs in case from the CLI arg "p17".
+        history_path = tmp_path / ".local/share/pc-switcher/sync-history.json"
+        history_path.parent.mkdir(parents=True, exist_ok=True)
+        history_path.write_text(_history_json("target", "P17"))
+
+        # Target (p17): last synced as SOURCE, peer recorded as "fleksi" (lowercase,
+        # the CLI arg the user typed on p17) — differs in case from "Fleksi".
+        orchestrator = _make_orchestrator(
+            mock_config,
+            target=target_name,
+            remote_stdout=_history_json("source", "fleksi"),
+        )
+        orchestrator._source_hostname = source_name  # pyright: ignore[reportPrivateUsage]
+
+        with patch.object(sys, "stdin", _mock_isatty(False)):
+            result = await orchestrator._check_out_of_order()  # pyright: ignore[reportPrivateUsage]
+
+        assert result is True
+        # No warning, no prompt: the case-only difference is a clean back-sync.
+        cast(MagicMock, orchestrator._logger).warning.assert_not_called()  # pyright: ignore[reportPrivateUsage]
+        cast(MagicMock, orchestrator._ui).pause.assert_not_called()  # pyright: ignore[reportPrivateUsage]
+
+    @pytest.mark.asyncio
+    async def test_consecutive_push_detected_across_casing(
+        self,
+        mock_config: MagicMock,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Consecutive push (W3) is still detected when the resolved target hostname
+        differs in case from the local peer record — case-insensitive match must not
+        let a genuine repeat push slip through as clean."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        source_name = "source-host"
+
+        # Local: this machine was SOURCE, peer recorded as "P17".
+        history_path = tmp_path / ".local/share/pc-switcher/sync-history.json"
+        history_path.parent.mkdir(parents=True, exist_ok=True)
+        history_path.write_text(_history_json("source", "P17"))
+
+        # Target resolves its own hostname as "p17" (lowercase); target history shows
+        # it last synced with this source (clean-looking), but we are pushing again.
+        orchestrator = _make_orchestrator(
+            mock_config,
+            target="p17",
+            remote_stdout=_history_json("target", source_name),
+        )
+        orchestrator._source_hostname = source_name  # pyright: ignore[reportPrivateUsage]
+        orchestrator._target_canonical_hostname = "p17"  # pyright: ignore[reportPrivateUsage]
+
+        with patch.object(sys, "stdin", _mock_isatty(False)):
+            result = await orchestrator._check_out_of_order()  # pyright: ignore[reportPrivateUsage]
+
+        # W3 fires → non-interactive → False, warning shown.
+        assert result is False
+        cast(MagicMock, orchestrator._console).print.assert_called()  # pyright: ignore[reportPrivateUsage]
+
+
+class TestResolveTargetCanonicalHostname:
+    """_resolve_target_canonical_hostname queries the target the same way the source
+    resolves its own hostname, and falls back to the CLI argument on failure."""
+
+    @pytest.mark.asyncio
+    async def test_resolves_hostname_over_ssh(self, mock_config: MagicMock) -> None:
+        """A successful query overwrites the CLI-argument fallback with the real hostname."""
+        orchestrator = _make_orchestrator(
+            mock_config,
+            target="p17",
+            remote_stdout="P17\n",
+        )
+        assert orchestrator._target_canonical_hostname == "p17"  # pyright: ignore[reportPrivateUsage]
+
+        await orchestrator._resolve_target_canonical_hostname()  # pyright: ignore[reportPrivateUsage]
+
+        assert orchestrator._target_canonical_hostname == "P17"  # pyright: ignore[reportPrivateUsage]
+        # The SSH-connectable name is untouched (rsync/SSH destination).
+        assert orchestrator._target_hostname == "p17"  # pyright: ignore[reportPrivateUsage]
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_cli_arg_on_failure(self, mock_config: MagicMock) -> None:
+        """A failed/empty query keeps the CLI-argument fallback."""
+        orchestrator = _make_orchestrator(
+            mock_config,
+            target="p17",
+            remote_stdout="",
+            remote_exit_code=1,
+        )
+
+        await orchestrator._resolve_target_canonical_hostname()  # pyright: ignore[reportPrivateUsage]
+
+        assert orchestrator._target_canonical_hostname == "p17"  # pyright: ignore[reportPrivateUsage]
+
+
 class TestUpdateSyncHistoryWithPeer:
     """_update_sync_history records last_peer on both source and target."""
 
@@ -683,6 +802,26 @@ class TestUpdateSyncHistoryWithPeer:
         data = json.loads(history_path.read_text())
         assert data["last_role"] == "source"
         assert data["last_peer"] == "target-host"
+
+    @pytest.mark.asyncio
+    async def test_local_history_records_resolved_hostname_not_cli_arg(
+        self,
+        mock_config: MagicMock,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """last_peer is the target's resolved hostname, not the (possibly aliased) CLI arg."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        orchestrator = Orchestrator(target="p17.lan", config=mock_config)
+        orchestrator._target_canonical_hostname = "P17"  # pyright: ignore[reportPrivateUsage]
+        orchestrator._remote_executor = None  # pyright: ignore[reportPrivateUsage]
+        orchestrator._logger = MagicMock()  # pyright: ignore[reportPrivateUsage]
+
+        await orchestrator._update_sync_history()  # pyright: ignore[reportPrivateUsage]
+
+        data = json.loads((tmp_path / ".local/share/pc-switcher/sync-history.json").read_text())
+        assert data["last_peer"] == "P17"
 
     @pytest.mark.asyncio
     async def test_remote_history_command_includes_peer(

--- a/tests/unit/test_sync_history.py
+++ b/tests/unit/test_sync_history.py
@@ -18,6 +18,7 @@ from pcswitcher.sync_history import (
     get_last_role_with_error,
     get_last_sync_state,
     get_record_role_command,
+    hostnames_equal,
     parse_sync_state,
     record_role,
 )
@@ -367,3 +368,23 @@ class TestGetRecordRoleCommand:
         assert history_file.exists()
         actual = json.loads(history_file.read_text())
         assert actual["last_role"] == "source"
+
+
+class TestHostnamesEqual:
+    """hostnames_equal compares case-insensitively and treats None as no-match."""
+
+    @pytest.mark.parametrize(
+        ("a", "b", "expected"),
+        [
+            ("P17", "p17", True),
+            ("Fleksi", "fleksi", True),
+            ("host", "host", True),
+            ("host-a", "host-b", False),
+            ("P17", None, False),
+            (None, "p17", False),
+            (None, None, False),
+            ("", "", True),
+        ],
+    )
+    def test_hostnames_equal(self, a: str | None, b: str | None, expected: bool) -> None:
+        assert hostnames_equal(a, b) is expected


### PR DESCRIPTION
## Problem

A clean back-sync (`p17 → Fleksi`, then `Fleksi → p17`) raised a spurious warning:

> ⚠ Target Last Synced with a Different Machine

The topology check (`_check_out_of_order`) recognises the clean A→B→A pattern by matching recorded `last_peer` values, but the two ends recorded the same machine under different names:

| Machine | recorded `last_peer` | source |
|---|---|---|
| p17 | `fleksi` | the CLI arg the user typed: `sync fleksi` |
| Fleksi | `P17` | p17's `socket.gethostname()` |

Fleksi's real hostname is `Fleksi` (capital F). The suppression check does exact string equality — `"fleksi" == "Fleksi"` → `False` — so the clean back-sync fell into the machine-C (W2) branch. Harmless under `--dry-run` (ADR-014: log and proceed), but a real run would prompt for confirmation on every back-sync.

Root cause: the source records its peer from the **typed CLI argument** while the target records its peer from **`socket.gethostname()`** — two different acquisition paths that mismatch whenever the typed name differs in case (or is an alias/IP).

## Fix

- Acquire the target's hostname the **same way** the source acquires its own: query the target's `socket.gethostname()` over SSH (`get_hostname_command()`), and record/compare that instead of the CLI argument. The CLI argument stays the SSH/rsync connection address (`folder_sync` uses it as the rsync destination host).
- Compare peers **case-insensitively** (`hostnames_equal`) as defense in depth and to reconcile history written before this change.

## Tests

- `hostnames_equal`: case-insensitivity + `None` handling.
- `_resolve_target_canonical_hostname`: resolves over SSH; falls back to the CLI arg on failure; leaves the connection address untouched.
- Regression: a case-mismatched back-sync is treated as clean (no warning); a genuine consecutive push (W3) is still detected across casing; `last_peer` records the resolved hostname, not the CLI arg.

Full suite: 642 unit tests green; ruff + basedpyright clean.

## Docs

ADR-015 refinement subsection + `architecture.md` hostname-resolution note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)