### PR TITLE
feat(folder_sync): human-readable transferred size in sync summary

### DIFF
--- a/src/pcswitcher/disk.py
+++ b/src/pcswitcher/disk.py
@@ -11,9 +11,25 @@ from pcswitcher.models import CommandResult
 __all__ = [
     "DiskSpace",
     "check_disk_space",
+    "format_bytes",
     "parse_df_output",
     "parse_threshold",
 ]
+
+
+def format_bytes(num_bytes: int) -> str:
+    """Format a byte count as a human-readable string using binary (IEC) units.
+
+    Example: ``557587395`` → ``"531.8 MiB"``. Use for human-facing summaries;
+    keep exact byte counts for DEBUG-level diagnostics.
+    """
+    value = float(num_bytes)
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if value < 1024 or unit == "TiB":
+            precision = 0 if unit == "B" else 1
+            return f"{value:.{precision}f} {unit}"
+        value /= 1024
+    raise AssertionError("unreachable: TiB branch returns")
 
 
 @dataclass(frozen=True)

--- a/src/pcswitcher/jobs/disk_space_monitor.py
+++ b/src/pcswitcher/jobs/disk_space_monitor.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from pcswitcher.disk import check_disk_space, parse_threshold
+from pcswitcher.disk import check_disk_space, format_bytes, parse_threshold
 from pcswitcher.models import (
     ConfigError,
     DiskSpaceCriticalError,
@@ -169,7 +169,7 @@ class DiskSpaceMonitorJob(BackgroundJob):
                         free_space_str = f"{free_percent:.1f}%"
                 elif disk_space.available_bytes < critical_value:
                     is_critical = True
-                    free_space_str = self._format_bytes(disk_space.available_bytes)
+                    free_space_str = format_bytes(disk_space.available_bytes)
 
                 if is_critical:
                     self._log(
@@ -203,7 +203,7 @@ class DiskSpaceMonitorJob(BackgroundJob):
                         f"Disk space getting low on {hostname}",
                         mount_point=self.mount_point,
                         available_bytes=disk_space.available_bytes,
-                        available_formatted=self._format_bytes(disk_space.available_bytes),
+                        available_formatted=format_bytes(disk_space.available_bytes),
                         warning_threshold=self.context.config["warning_threshold"],
                     )
 
@@ -217,20 +217,3 @@ class DiskSpaceMonitorJob(BackgroundJob):
                 f"Disk space monitoring cancelled for {self.mount_point}",
             )
             raise
-
-    def _format_bytes(self, bytes_value: int) -> str:
-        """Format bytes as human-readable string.
-
-        Args:
-            bytes_value: Number of bytes
-
-        Returns:
-            Formatted string like "45.2 GiB"
-        """
-        if bytes_value >= 2**30:
-            return f"{bytes_value / 2**30:.1f} GiB"
-        if bytes_value >= 2**20:
-            return f"{bytes_value / 2**20:.1f} MiB"
-        if bytes_value >= 2**10:
-            return f"{bytes_value / 2**10:.1f} KiB"
-        return f"{bytes_value} B"

--- a/src/pcswitcher/jobs/folder_sync.py
+++ b/src/pcswitcher/jobs/folder_sync.py
@@ -21,6 +21,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, ClassVar, override
 
+from pcswitcher.disk import format_bytes
 from pcswitcher.jobs.base import SyncJob
 from pcswitcher.models import FirstSyncScope, Host, LogLevel, ProgressUpdate, ValidationError
 
@@ -607,14 +608,20 @@ class FolderSyncJob(SyncJob):
             files_transferred = seed_files + mirror_files
             bytes_transferred = seed_bytes + mirror_bytes
 
-            # Per-folder summary (D-16)
+            # Per-folder summary (D-16). Human-readable size at INFO; exact byte
+            # count kept at DEBUG for precise diagnostics (#189).
             self._log(
                 Host.SOURCE,
                 LogLevel.INFO,
                 f"{prefix}Completed sync of {folder.path!r}: "
                 f"{files_transferred} files transferred, "
-                f"{bytes_transferred} bytes, "
+                f"{format_bytes(bytes_transferred)}, "
                 f"{files_deleted} deletions",
+            )
+            self._log(
+                Host.SOURCE,
+                LogLevel.DEBUG,
+                f"{prefix}Transferred {bytes_transferred} bytes for {folder.path!r}",
             )
 
         # Progress is reported per folder, so the bar resets for each one and would

--- a/src/pcswitcher/orchestrator.py
+++ b/src/pcswitcher/orchestrator.py
@@ -19,7 +19,7 @@ from pcswitcher.config import Configuration
 from pcswitcher.config_sync import sync_config_to_target
 from pcswitcher.confirmer import Confirmer, TerminalUIConfirmer
 from pcswitcher.connection import Connection
-from pcswitcher.disk import DiskSpace, check_disk_space, parse_threshold
+from pcswitcher.disk import DiskSpace, check_disk_space, format_bytes, parse_threshold
 from pcswitcher.events import EventBus
 from pcswitcher.executor import LocalExecutor, RemoteExecutor, RemoteProcess
 from pcswitcher.jobs.base import Job, SyncJob
@@ -918,15 +918,6 @@ class Orchestrator:
         source_task = check_disk_space(self._local_executor, "/")
         target_task = check_disk_space(self._remote_executor, "/")
         source_disk, target_disk = await asyncio.gather(source_task, target_task)
-
-        # Helper to format bytes in human-readable form
-        def format_bytes(bytes_value: int) -> str:
-            value = float(bytes_value)
-            for unit in ["B", "KiB", "MiB", "GiB", "TiB"]:
-                if value < 1024:
-                    return f"{value:.1f}{unit}"
-                value /= 1024
-            return f"{value:.1f}PiB"
 
         # Helper to check if disk space is sufficient
         def is_sufficient(disk_space: DiskSpace, threshold_type: str, threshold_value: int) -> bool:

--- a/tests/unit/test_disk_format.py
+++ b/tests/unit/test_disk_format.py
@@ -1,0 +1,27 @@
+"""Tests for human-readable byte formatting (disk.format_bytes)."""
+
+from __future__ import annotations
+
+import pytest
+
+from pcswitcher.disk import format_bytes
+
+
+@pytest.mark.parametrize(
+    ("num_bytes", "expected"),
+    [
+        (0, "0 B"),
+        (512, "512 B"),
+        (1023, "1023 B"),
+        (1024, "1.0 KiB"),
+        (1536, "1.5 KiB"),
+        (2**20, "1.0 MiB"),
+        (557587395, "531.8 MiB"),  # the size from issue #189
+        (2**30, "1.0 GiB"),
+        (5 * 2**30, "5.0 GiB"),
+        (2**40, "1.0 TiB"),
+        (3 * 2**50, "3072.0 TiB"),  # petabyte range stays in TiB
+    ],
+)
+def test_format_bytes(num_bytes: int, expected: str) -> None:
+    assert format_bytes(num_bytes) == expected


### PR DESCRIPTION
Fixes #189.

## What
Show MiB/GiB in the INFO per-folder sync summary instead of raw bytes; keep the exact byte count at DEBUG level.

Before:
```
Completed sync of '/home/janfr': 6244 files transferred, 557587395 bytes, 2225 deletions
```
After:
```
Completed sync of '/home/janfr': 6244 files transferred, 531.8 MiB, 2225 deletions
```

## Changes
- Add `disk.format_bytes()` (binary/IEC units, 1 decimal) and consolidate the three pre-existing duplicate byte formatters (`folder_sync` summary, `disk_space_monitor`, orchestrator preflight) onto it.
- `folder_sync`: INFO summary uses `format_bytes`; new DEBUG line retains exact bytes.
- New test `tests/unit/test_disk_format.py`.

## Verification
`ruff`, `basedpyright` clean on touched files; full unit suite (595) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AtNMN3MmxXnutgAm8Xkk6T