### PR TITLE
fix(folder_sync): show progress bar during incremental-recursion scan (#191)

### DIFF
--- a/.planning/debug/foldersync-progressbar-hidden.md
+++ b/.planning/debug/foldersync-progressbar-hidden.md
@@ -1,0 +1,92 @@
+---
+status: awaiting_human_verify
+trigger: |
+  gh #191 "Folder sync progress bar not showing until done".
+  When syncing, even a very long first sync (>10 min), the progress bar doesn't
+  appear while rsync runs. It appears only when done — and empty, not at 100%
+  (or an instant 100% then cleared as next phases start). Two unclear phone
+  photos of the screen attached to the issue; not needed — root cause verified
+  from code + rsync behavior.
+created: 2026-07-20
+updated: 2026-07-20
+---
+
+# Debug: folder-sync progress bar hidden until done (#191)
+
+## Symptoms
+
+- expected: per-folder progress bar climbs smoothly while rsync transfers, reaching 100% at completion.
+- actual: no bar at all during the (long) rsync run; a bar appears only at the end, and looks empty / not-100%.
+- error_messages: none — purely a TUI progress display gap.
+- timeline: reproducible on long first syncs (>10 min) of a large tree (e.g. /home). Known/deferred: flagged in `.planning/debug/folder-sync-dry-run-7-bytes.md` (Eliminated + blind_spots) as a separate minor issue.
+- reproduction: `pc-switcher sync <target>` on a large first sync; watch the folder_sync progress bar.
+
+## Current Focus
+
+status: FIXED + VERIFIED. Awaiting human verification before archiving.
+next_action: none — checkpoint request pending user confirmation.
+
+reasoning_checkpoint:
+  hypothesis: >
+    `_PROGRESS2_RE` (src/pcswitcher/jobs/folder_sync.py:38) hard-codes `to-chk=` in
+    its trailing group. rsync `--info=progress2` emits the counter as `ir-chk=`
+    (incremental-recursion check) while it is still BUILDING the file list, and
+    only switches to `to-chk=` once the full list is known. Incremental recursion
+    is rsync's default and, for a large tree, interleaves with the transfer and
+    dominates the whole run — so nearly every progress2 frame during a big first
+    sync carries `ir-chk=`, none of which the regex matches. With no match,
+    `_stream_rsync` never calls `_report_progress`, so `update_job_progress`
+    never lazily creates the Rich progress task (ui.py:224) and no bar is drawn.
+    The bar appears only once rsync flips to `to-chk=` near the very end — by which
+    point most bytes are already transferred, so it flashes near-done/at-100 rather
+    than climbing, matching the "appears only when done, looks empty/not-100%" report.
+  confirming_evidence:
+    - "Ran rsync 3.2.7 `-aAXHS --numeric-ids --info=progress2` on a 2400-file / 60-dir tree (mirrors the job's flag baseline). Converting \\r→\\n and counting chk tokens: 1370 `ir-chk=` frames vs 1091 `to-chk=` frames. The ir-chk frames come FIRST and carry climbing percentages (0%→…), none of which `_PROGRESS2_RE` matches."
+    - "Sample captured ir-chk frame: `20.000   0%    0,00kB/s    0:00:00 (xfr#1, ir-chk=1039/1101)` — structurally identical to a to-chk frame except the literal `ir-chk`."
+    - "The larger and more directory-heavy the source tree, the longer rsync stays in the ir-chk phase relative to to-chk — so a real /home first sync spends the overwhelming majority of its runtime emitting only ir-chk frames, exactly the reported no-bar-for-10+-min behavior."
+  falsification_test: >
+    If the hypothesis were wrong, feeding an `ir-chk=` progress2 line through the
+    UNMODIFIED `_stream_rsync` would still emit a `_report_progress` call. It does
+    not (regex returns no match). After widening the regex to accept `ir-chk`, the
+    same line must produce a ProgressUpdate — and it does.
+  fix_rationale: >
+    Change the regex's `to-chk=` to match either token, e.g.
+    `(?:ir|to)-chk=\d+/(\d+)`. The rest of the line shape is identical across both
+    phases, so group numbering and `_parse_size_to_bytes` are unaffected. The bar is
+    driven by group-2 percent (byte-based, present in ir-chk frames too), so the
+    fluctuating group-4 denominator during ir-chk (total grows as files are
+    discovered) does NOT destabilize the bar — `update_job_progress` only uses
+    `total` when `percent is None`, and percent is always set on this path.
+  blind_spots: >
+    Not reproduced against a real multi-minute /home sync from this sandbox (no
+    target SSH). The "empty at end" second screenshot is not fully explained — it
+    may be the brief to-chk flash, execute()'s final percent=100 update
+    (folder_sync.py:624), or a subsequent phase's bar; confirm the widened regex
+    makes the bar climb during ir-chk and that the end state reads 100%.
+
+## Evidence
+
+- timestamp: 2026-07-20
+  finding: `_PROGRESS2_RE` = `(\d+[\d,.]*[KMGT]?)\s+(\d+)%\s+\S+\s+\S+\s+\(xfr#(\d+),\s*to-chk=\d+/(\d+)\)` (src/pcswitcher/jobs/folder_sync.py:38). The trailing `to-chk=` is literal. `_stream_rsync` (folder_sync.py:495-513) calls `_report_progress` ONLY on a regex match; the bar's Rich task is created lazily on the first `update_job_progress` call (src/pcswitcher/ui.py:224-230). No match → no task → no bar.
+- timestamp: 2026-07-20
+  finding: EMPIRICAL REPRO — rsync 3.2.7, `-aAXHS --numeric-ids --info=progress2`, 2400 files / 60 dirs. `tr '\r' '\n' | grep -oE '(ir-chk|to-chk)=' | sort | uniq -c` → 1370 ir-chk, 1091 to-chk. ir-chk frames are emitted first (during file-list build) with climbing percentages; only after the list is complete does rsync switch to to-chk. `_PROGRESS2_RE` matches none of the 1370 ir-chk frames.
+- timestamp: 2026-07-20
+  finding: Existing tests (tests/unit/jobs/test_folder_sync.py) exercise ONLY `to-chk` fixtures (lines 694, 737, 784-785, 799, 816). No test covers an `ir-chk` frame — which is why the gap shipped. This is the test hole to close.
+- timestamp: 2026-07-20
+  finding: Prior session `.planning/debug/folder-sync-dry-run-7-bytes.md` already documented this gap as known-but-deferred (line 99, and Eliminated hypothesis lines 115-116; blind_spots line 71-76): "the regex never matches ir-chk lines... left unfixed here since it is not the reported bug and fixing it is a separate, larger change (would need to also handle the fluctuating denominator during ir-chk)." #191 is that deferred bug.
+
+## Eliminated
+
+(none yet — root cause confirmed on first hypothesis via empirical repro)
+
+## Resolution
+
+root_cause: `_PROGRESS2_RE` (src/pcswitcher/jobs/folder_sync.py:38) matched only the literal `to-chk=` token, but rsync `--info=progress2` emits `ir-chk=` (incremental-recursion) frames while building the file list — the dominant phase of a large first sync. No match meant `_stream_rsync` never called `_report_progress`, so the Rich progress task was never lazily created (ui.py:224) and no bar appeared until rsync flipped to `to-chk=` near the end.
+
+fix: widened `_PROGRESS2_RE`'s trailing token from `to-chk=` to `(?:ir|to)-chk=` so it matches both incremental-recursion and total-known frames. Updated the surrounding comment block to document both prefixes and the #191 rationale.
+
+verification: added `test_ir_chk_progress_line_emits_report_progress` (tests/unit/jobs/test_folder_sync.py) feeding a real ir-chk progress2 line through the unmodified `_stream_rsync`; confirmed it FAILS against the pre-fix regex (0 progress calls) via `git stash` on folder_sync.py, then PASSES post-fix. Full suite: `uv run pytest` (643 passed), `uv run ruff check .` + `ruff format --check .` (clean), `uv run basedpyright` (0 errors), `uv run codespell` on changed files (clean).
+
+files_changed:
+- src/pcswitcher/jobs/folder_sync.py (regex + comment)
+- tests/unit/jobs/test_folder_sync.py (regression test)

--- a/README.md
+++ b/README.md
@@ -77,24 +77,26 @@ After sync completes, power off the source machine and resume work on target.
 
 The sequence stops at the first failure (raising an exception), and the `finally` cleanup always runs (release locks, kill remote processes, close the connection).
 
-1. **Load config & arm interrupt handling** (CLI, before the orchestrator). Read `~/.config/pc-switcher/config.yaml`, start the asyncio loop, install the SIGINT handler that triggers graceful cleanup.
-2. **Acquire source lock.** Local lock file; this machine cannot join any other sync (as source or target) while this one runs.
-3. **Establish SSH connection.** Creates the local and remote executors every later step uses. Nothing touches the target before this point.
-4. **Acquire target lock.** A persistent remote process holds the same unified lock on the target; released during cleanup.
-5. **Out-of-order / target-state check.** Reads `last_role` and `last_peer` from the local and target sync history to detect situations where the target may hold independent state — for example, no prior sync history exists (W1), the target last synced with a different machine (W2 — machine-C scenario), or this source is pushing again without receiving a back-sync first (W3). Shows a warning and asks for confirmation; the sync is never hard-aborted for any of these cases since the A→B / work-on-A / A→B again workflow is legitimate (GitHub #159). Skipped with `--allow-out-of-order`. In `--dry-run` mode the warning is logged and the sync continues.
-6. **Discover & validate jobs.**
+Before the numbered steps, the CLI (outside the orchestrator) reads `~/.config/pc-switcher/config.yaml`, starts the asyncio loop, and installs the SIGINT handler that triggers graceful cleanup. The orchestrator then runs the ten steps below, which the live UI shows as `Step N/total` and the code marks with matching `# Step N` comments in `Orchestrator.run()`:
+
+1. **Acquire source lock.** Local lock file; this machine cannot join any other sync (as source or target) while this one runs.
+2. **Establish SSH connection.** Creates the local and remote executors every later step uses. Nothing touches the target before this point.
+3. **Acquire target lock.** A persistent remote process holds the same unified lock on the target; released during cleanup.
+   - *Between steps 3 and 4 (not a progress step): out-of-order / target-state check.* Reads `last_role` and `last_peer` from the local and target sync history to detect situations where the target may hold independent state — for example, no prior sync history exists (W1), the target last synced with a different machine (W2 — machine-C scenario), or this source is pushing again without receiving a back-sync first (W3). Shows a warning and asks for confirmation; the sync is never hard-aborted for any of these cases since the A→B / work-on-A / A→B again workflow is legitimate (GitHub #159). Skipped with `--allow-out-of-order`. In `--dry-run` mode the warning is logged and the sync continues.
+4. **Discover & validate jobs.**
    - Load enabled jobs from config
    - Validate their config
    - Run each job's `validate()` against live system state: checks `sudo rsync` availability, `acl` package installation, and source folder existence. Nothing has been mutated yet.
-7. **Disk-space preflight.** Check free space on both hosts in parallel against `preflight_minimum`; abort if either is short — so snapshots and rsync don't run a disk into ENOSPC.
-8. **Pre-sync snapshots.** Create btrfs snapshots on both hosts. This is the rollback point; every mutating step below happens after it.
-9. **Install/upgrade pc-switcher on target.** Ensures the target has a compatible version to run its side of later jobs. After snapshots, so a bad install is recoverable.
-10. **Sync config to target.** Copy this machine's config to the target (prompting on diff unless `--yes`), so both ends run jobs with identical settings.
-11. **Run sync jobs sequentially.** The actual data movement (e.g. `folder_sync` via rsync-over-SSH as root on both ends). A background disk-space monitor runs concurrently and aborts the sync if free space crosses `runtime_minimum`. First job failure stops the run.
-12. **Post-sync snapshots.** Snapshot both hosts again, capturing the synced state.
-13. **Record sync history.** On success, write `last_role` and `last_peer` on both machines to enable the step 5 topology check next time. Skipped in `--dry-run`.
+5. **Disk-space preflight.** Check free space on both hosts in parallel against `preflight_minimum`; abort if either is short — so snapshots and rsync don't run a disk into ENOSPC.
+6. **Pre-sync snapshots.** Create btrfs snapshots on both hosts. This is the rollback point; every mutating step below happens after it.
+7. **Install/upgrade pc-switcher on target.** Ensures the target has a compatible version to run its side of later jobs. After snapshots, so a bad install is recoverable.
+8. **Sync config to target.** Copy this machine's config to the target (prompting on diff unless `--yes`), so both ends run jobs with identical settings.
+9. **Run sync jobs sequentially.** The actual data movement (e.g. `folder_sync` via rsync-over-SSH as root on both ends). A background disk-space monitor runs concurrently and aborts the sync if free space crosses `runtime_minimum`. First job failure stops the run.
+10. **Post-sync snapshots.** Snapshot both hosts again, capturing the synced state.
 
-With `--dry-run`, the workflow previews without writing state (no history update, no snapshots, no mutations). rsync `--dry-run` lists the exact files and deletions that would occur; deletions are recorded in the FULL-level log so you can audit what would be destroyed before committing to a live sync. `--allow-out-of-order` skips the step 5 target-state confirmation.
+On success, after step 10 (not a progress step), the workflow records sync history: it writes `last_role` and `last_peer` on both machines to enable the out-of-order / target-state check next time. Skipped in `--dry-run`.
+
+With `--dry-run`, the workflow previews without writing state (no history update, no snapshots, no mutations). rsync `--dry-run` lists the exact files and deletions that would occur; deletions are recorded in the FULL-level log so you can audit what would be destroyed before committing to a live sync. `--allow-out-of-order` skips the out-of-order / target-state confirmation.
 
 ## Configuration
 

--- a/src/pcswitcher/jobs/base.py
+++ b/src/pcswitcher/jobs/base.py
@@ -182,7 +182,7 @@ class SyncJob(Job):
         for future non-rsync jobs without any orchestrator change.
 
         Called as a classmethod before job instances exist — the first-sync check
-        runs before Phase 4 job discovery.
+        runs before step 4 job discovery.
 
         Args:
             config: This job's configuration dict from config.yaml.

--- a/src/pcswitcher/jobs/folder_sync.py
+++ b/src/pcswitcher/jobs/folder_sync.py
@@ -27,6 +27,7 @@ from pcswitcher.models import FirstSyncScope, Host, LogLevel, ProgressUpdate, Va
 # Matches rsync --info=progress2 output, e.g.:
 #   "9.53G 21% 317.26MB/s 0:00:28 (xfr#83063, to-chk=443926/538653)"
 #   "29,958,458  99%   27.90GB/s    0:00:00 (xfr#298201, to-chk=1200/300501)"
+#   "20.000   0%    0,00kB/s    0:00:00 (xfr#1, ir-chk=1039/1101)"
 # Group 1: size token (e.g. "9.53G" or "29,958,458") — used to compute
 # bytes_transferred (WR-01).  rsync thousands-groups the plain byte counter with
 # a locale-dependent separator (',' on C/en_US, '.' on nl_BE-style), so the size
@@ -35,7 +36,14 @@ from pcswitcher.models import FirstSyncScope, Host, LogLevel, ProgressUpdate, Va
 # bytes_transferred by orders of magnitude while files-transferred (ungrouped)
 # stayed correct.
 # Group 2: percent complete.  Group 3: files transferred so far.  Group 4: total-to-check.
-_PROGRESS2_RE = re.compile(r"(\d+[\d,.]*[KMGT]?)\s+(\d+)%\s+\S+\s+\S+\s+\(xfr#(\d+),\s*to-chk=\d+/(\d+)\)")
+# The trailing counter is `ir-chk=` (incremental-recursion, file list still being
+# built) or `to-chk=` (total known) — rsync only switches to to-chk once the full
+# file list is discovered.  For a large tree, incremental recursion dominates the
+# whole run, so matching only to-chk left the progress bar hidden for most of a
+# big first sync (#191): no match meant no `_report_progress` call, so the Rich
+# task was never lazily created (ui.py:224).  Both prefixes carry the same
+# percent/byte-based progress, so matching either is safe.
+_PROGRESS2_RE = re.compile(r"(\d+[\d,.]*[KMGT]?)\s+(\d+)%\s+\S+\s+\S+\s+\(xfr#(\d+),\s*(?:ir|to)-chk=\d+/(\d+)\)")
 
 # pc-switcher's own runtime STATE lives under the invoking user's home and must
 # stay machine-local: sync-history.json is the topology-safety state (ADR-015) that

--- a/src/pcswitcher/orchestrator.py
+++ b/src/pcswitcher/orchestrator.py
@@ -215,7 +215,7 @@ class Orchestrator:
     def _create_job_context(self, config: dict[str, Any]) -> JobContext:
         """Create JobContext with current orchestrator state.
 
-        Must only be called after SSH connection is established (Phase 2+).
+        Must only be called after SSH connection is established (step 2+).
         """
         assert self._local_executor is not None
         assert self._remote_executor is not None
@@ -232,7 +232,7 @@ class Orchestrator:
             allow_first_sync=self._allow_first_sync,
             confirmer=self._confirmer,
             # Connection is always set when _create_job_context is called in
-            # production (Phase 2+), but unit tests mock executors without a
+            # production (step 2+), but unit tests mock executors without a
             # real connection, so fall back to None (JobContext accepts it).
             target_username=self._connection.username if self._connection is not None else None,
         )
@@ -269,10 +269,10 @@ class Orchestrator:
         # TerminalUI does not start the Live (start() is still called below),
         # so creating it early is safe.
         #
-        # Calculate total steps: 8 system phases + sync jobs + 1 post-snapshot
-        # System phases: 1=source lock, 2=SSH, 3=target lock, 4=validation,
+        # Calculate total steps: 8 system steps + sync jobs + 1 post-snapshot
+        # System steps: 1=source lock, 2=SSH, 3=target lock, 4=validation,
         # 5=disk check, 6=pre-snapshots, 7=install on target, 8=config sync
-        # Count only enabled jobs for the initial estimate; Phase 4 discovery may
+        # Count only enabled jobs for the initial estimate; step 4 discovery may
         # reduce this further (e.g. module not found), so we correct via
         # set_total_steps() after _discover_and_validate_jobs() returns.
         total_steps = 8 + sum(1 for enabled in self._config.sync_jobs.values() if enabled) + 1
@@ -323,28 +323,29 @@ class Orchestrator:
             )
 
         try:
-            # Phase 1: Acquire source lock
+            # Step 1: Acquire source lock
             self._logger.info("Acquiring source lock", extra={"job": "orchestrator", "host": "source"})
             await self._acquire_source_lock()
             self._ui.set_current_step(1, "Source lock")
 
-            # Phase 2: Establish SSH connection
+            # Step 2: Establish SSH connection
             self._logger.info("Connecting to target", extra={"job": "orchestrator", "host": "source"})
             await self._establish_connection()
             assert self._remote_executor is not None
             self._ui.set_current_step(2, "Connect to target")
 
-            # Phase 3: Acquire target lock
+            # Step 3: Acquire target lock
             self._logger.info("Acquiring target lock", extra={"job": "orchestrator", "host": "target"})
             await self._acquire_target_lock()
             self._ui.set_current_step(3, "Target lock")
 
-            # Topology out-of-order / target-state check (between Phase 3 and 4):
-            # runs after the target lock so we can read the target's sync-history over SSH.
+            # Topology out-of-order / target-state check (between steps 3 and 4, no
+            # progress step of its own): runs after the target lock so we can read
+            # the target's sync-history over SSH.
             if not await self._check_out_of_order():
                 raise SyncAbortedByUser("Sync aborted at the out-of-order / target-state check")
 
-            # Phase 4: Job discovery and validation
+            # Step 4: Job discovery and validation
             self._logger.info("Discovering and validating jobs", extra={"job": "orchestrator", "host": "source"})
             jobs = await self._discover_and_validate_jobs()
             # Correct the total now that we know the exact jobs that will run.
@@ -353,16 +354,16 @@ class Orchestrator:
             self._ui.set_total_steps(8 + len(jobs) + 1)
             self._ui.set_current_step(4, "Discover jobs")
 
-            # Phase 5: Disk space preflight check
+            # Step 5: Disk space preflight check
             await self._check_disk_space_preflight()
             self._ui.set_current_step(5, "Disk check")
 
-            # Phase 6: Pre-sync snapshots
+            # Step 6: Pre-sync snapshots
             self._logger.info("Creating pre-sync snapshots", extra={"job": "orchestrator", "host": "source"})
             await self._create_snapshots(SnapshotPhase.PRE)
             self._ui.set_current_step(6, "Pre-sync snapshots")
 
-            # Phase 7: Install/upgrade pc-switcher on target (after snapshots for rollback safety)
+            # Step 7: Install/upgrade pc-switcher on target (after snapshots for rollback safety)
             self._logger.info(
                 "Ensuring pc-switcher is installed on target",
                 extra={"job": "orchestrator", "host": "target"},
@@ -370,17 +371,17 @@ class Orchestrator:
             await self._install_on_target_job()
             self._ui.set_current_step(7, "Install on target")
 
-            # Phase 8: Sync config from source to target
+            # Step 8: Sync config from source to target
             self._logger.info("Syncing configuration to target", extra={"job": "orchestrator", "host": "target"})
             await self._sync_config_to_target()
             self._ui.set_current_step(8, "Sync config")
 
-            # Phase 9: Execute sync jobs with background monitoring
+            # Step 9: Execute sync jobs with background monitoring
             self._logger.info("Starting sync operations", extra={"job": "orchestrator", "host": "source"})
             job_results = await self._execute_jobs(jobs)
             session.job_results = job_results
 
-            # Phase 10: Post-sync snapshots
+            # Step 10: Post-sync snapshots
             self._logger.info("Creating post-sync snapshots", extra={"job": "orchestrator", "host": "source"})
             await self._create_snapshots(SnapshotPhase.POST)
             self._ui.set_current_step(8 + len(jobs) + 1, "Post-sync snapshots")
@@ -567,8 +568,8 @@ class Orchestrator:
 
         Convention: job_name == module_name (e.g., "dummy_success" → pcswitcher.jobs.dummy_success).
         Dynamically imports the module and scans its attributes for a SyncJob subclass whose
-        `name` ClassVar matches. Shared by `_discover_and_validate_jobs` (Phase 4 job discovery)
-        and `_first_sync_scopes` (pre-Phase-4 first-sync messaging) so the import/scan logic
+        `name` ClassVar matches. Shared by `_discover_and_validate_jobs` (step 4 job discovery)
+        and `_first_sync_scopes` (pre-step-4 first-sync messaging) so the import/scan logic
         lives in exactly one place.
 
         Returns:
@@ -608,7 +609,7 @@ class Orchestrator:
 
         Resolves every enabled job in `self._config.sync_jobs` (config order) to its SyncJob
         class via `_resolve_sync_job_class`, then calls `describe_first_sync_scope()` on each —
-        this runs before Phase 4 job discovery, so classes (not instances) are used. Jobs that
+        this runs before step 4 job discovery, so classes (not instances) are used. Jobs that
         return None (no overwrite scope, or nothing in scope for their config) contribute
         nothing; the orchestrator's warning falls back to generic phrasing when this is empty.
         """

--- a/src/pcswitcher/ui.py
+++ b/src/pcswitcher/ui.py
@@ -356,7 +356,7 @@ class TerminalUI:
     def set_total_steps(self, total: int) -> None:
         """Correct the total step count once the actual number of jobs is known.
 
-        Called by the orchestrator after Phase 4 job discovery to replace the
+        Called by the orchestrator after step 4 job discovery to replace the
         initial estimate with the exact count of enabled, discoverable jobs.
         Refreshes the live render immediately so the display reflects the correction.
 

--- a/tests/unit/jobs/test_folder_sync.py
+++ b/tests/unit/jobs/test_folder_sync.py
@@ -744,6 +744,24 @@ class TestStreamRsync:
         assert update.percent == 21
         assert update.current == 83
 
+    async def test_ir_chk_progress_line_emits_report_progress(self) -> None:
+        """An ir-chk (incremental-recursion) progress2 line also triggers _report_progress.
+
+        Regression for #191: rsync emits `ir-chk=` while still building the file
+        list, and only switches to `to-chk=` once the list is complete. For a large
+        tree this dominates the run, so a regex matching only `to-chk=` left the
+        progress bar hidden for most of a big first sync.
+        """
+        progress_line = b"20.000   0%    0,00kB/s    0:00:00 (xfr#1, ir-chk=1039/1101)\r"
+        _, _, progress_calls = await self._run_stream([progress_line])
+
+        assert len(progress_calls) >= 1, "ir-chk progress2 line must produce a _report_progress call"
+        update = progress_calls[0]
+
+        assert isinstance(update, ProgressUpdate)
+        assert update.percent == 0
+        assert update.current == 1
+
     async def test_per_file_line_logged_at_full(self) -> None:
         """An --out-format per-file line is logged at LogLevel.FULL."""
         file_line = b">f+++++++++ path/to/file.txt\n"


### PR DESCRIPTION
## Problem

On a long first sync (>10 min), the folder_sync progress bar stayed hidden the whole run and only appeared at the very end (empty / not climbing). Reported in #191.

## Root cause

`_PROGRESS2_RE` (`src/pcswitcher/jobs/folder_sync.py`) matched only the literal `to-chk=` token. rsync `--info=progress2` emits `ir-chk=` (incremental-recursion) frames while it is still building the file list, switching to `to-chk=` only once the list is complete. For a large tree that scan phase dominates the entire run, so no progress2 frame matched → `_stream_rsync` never called `_report_progress` → the Rich progress task was never lazily created (`ui.py`) and no bar was drawn until rsync flipped to `to-chk=` near the end.

Reproduced with rsync 3.2.7 using the job's exact flag baseline: 1370 `ir-chk=` frames (emitted first, with climbing percentages) vs 1091 `to-chk=` frames on a 2400-file tree.

This gap was previously documented as known-but-deferred in the earlier `folder-sync-dry-run-7-bytes` debug session.

## Fix

Widen the trailing token from `to-chk=` to `(?:ir|to)-chk=`. Both prefixes carry the same percent/byte-based progress and identical group layout, so the parser and group numbering are unchanged.

## Tests

- New regression test `test_ir_chk_progress_line_emits_report_progress`, confirmed non-vacuous (fails against the pre-fix regex, passes after).
- Full gate green: `uv run pytest` (643 passed), ruff check/format, basedpyright (0/0/0), codespell.

## Manual verification (pending)

Display timing can't be observed from unit tests. Needs a real large sync (`pc-switcher sync <target>`) to confirm the bar appears early, climbs during the run, and reads 100% on completion.

Fixes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0184mwGGfjQSoNAvTdbig5b8