### PR TITLE
docs: reconcile sync step numbering across code, UI, and README (#186)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,24 +77,26 @@ After sync completes, power off the source machine and resume work on target.
 
 The sequence stops at the first failure (raising an exception), and the `finally` cleanup always runs (release locks, kill remote processes, close the connection).
 
-1. **Load config & arm interrupt handling** (CLI, before the orchestrator). Read `~/.config/pc-switcher/config.yaml`, start the asyncio loop, install the SIGINT handler that triggers graceful cleanup.
-2. **Acquire source lock.** Local lock file; this machine cannot join any other sync (as source or target) while this one runs.
-3. **Establish SSH connection.** Creates the local and remote executors every later step uses. Nothing touches the target before this point.
-4. **Acquire target lock.** A persistent remote process holds the same unified lock on the target; released during cleanup.
-5. **Out-of-order / target-state check.** Reads `last_role` and `last_peer` from the local and target sync history to detect situations where the target may hold independent state — for example, no prior sync history exists (W1), the target last synced with a different machine (W2 — machine-C scenario), or this source is pushing again without receiving a back-sync first (W3). Shows a warning and asks for confirmation; the sync is never hard-aborted for any of these cases since the A→B / work-on-A / A→B again workflow is legitimate (GitHub #159). Skipped with `--allow-out-of-order`. In `--dry-run` mode the warning is logged and the sync continues.
-6. **Discover & validate jobs.**
+Before the numbered steps, the CLI (outside the orchestrator) reads `~/.config/pc-switcher/config.yaml`, starts the asyncio loop, and installs the SIGINT handler that triggers graceful cleanup. The orchestrator then runs the ten steps below, which the live UI shows as `Step N/total` and the code marks with matching `# Step N` comments in `Orchestrator.run()`:
+
+1. **Acquire source lock.** Local lock file; this machine cannot join any other sync (as source or target) while this one runs.
+2. **Establish SSH connection.** Creates the local and remote executors every later step uses. Nothing touches the target before this point.
+3. **Acquire target lock.** A persistent remote process holds the same unified lock on the target; released during cleanup.
+   - *Between steps 3 and 4 (not a progress step): out-of-order / target-state check.* Reads `last_role` and `last_peer` from the local and target sync history to detect situations where the target may hold independent state — for example, no prior sync history exists (W1), the target last synced with a different machine (W2 — machine-C scenario), or this source is pushing again without receiving a back-sync first (W3). Shows a warning and asks for confirmation; the sync is never hard-aborted for any of these cases since the A→B / work-on-A / A→B again workflow is legitimate (GitHub #159). Skipped with `--allow-out-of-order`. In `--dry-run` mode the warning is logged and the sync continues.
+4. **Discover & validate jobs.**
    - Load enabled jobs from config
    - Validate their config
    - Run each job's `validate()` against live system state: checks `sudo rsync` availability, `acl` package installation, and source folder existence. Nothing has been mutated yet.
-7. **Disk-space preflight.** Check free space on both hosts in parallel against `preflight_minimum`; abort if either is short — so snapshots and rsync don't run a disk into ENOSPC.
-8. **Pre-sync snapshots.** Create btrfs snapshots on both hosts. This is the rollback point; every mutating step below happens after it.
-9. **Install/upgrade pc-switcher on target.** Ensures the target has a compatible version to run its side of later jobs. After snapshots, so a bad install is recoverable.
-10. **Sync config to target.** Copy this machine's config to the target (prompting on diff unless `--yes`), so both ends run jobs with identical settings.
-11. **Run sync jobs sequentially.** The actual data movement (e.g. `folder_sync` via rsync-over-SSH as root on both ends). A background disk-space monitor runs concurrently and aborts the sync if free space crosses `runtime_minimum`. First job failure stops the run.
-12. **Post-sync snapshots.** Snapshot both hosts again, capturing the synced state.
-13. **Record sync history.** On success, write `last_role` and `last_peer` on both machines to enable the step 5 topology check next time. Skipped in `--dry-run`.
+5. **Disk-space preflight.** Check free space on both hosts in parallel against `preflight_minimum`; abort if either is short — so snapshots and rsync don't run a disk into ENOSPC.
+6. **Pre-sync snapshots.** Create btrfs snapshots on both hosts. This is the rollback point; every mutating step below happens after it.
+7. **Install/upgrade pc-switcher on target.** Ensures the target has a compatible version to run its side of later jobs. After snapshots, so a bad install is recoverable.
+8. **Sync config to target.** Copy this machine's config to the target (prompting on diff unless `--yes`), so both ends run jobs with identical settings.
+9. **Run sync jobs sequentially.** The actual data movement (e.g. `folder_sync` via rsync-over-SSH as root on both ends). A background disk-space monitor runs concurrently and aborts the sync if free space crosses `runtime_minimum`. First job failure stops the run.
+10. **Post-sync snapshots.** Snapshot both hosts again, capturing the synced state.
 
-With `--dry-run`, the workflow previews without writing state (no history update, no snapshots, no mutations). rsync `--dry-run` lists the exact files and deletions that would occur; deletions are recorded in the FULL-level log so you can audit what would be destroyed before committing to a live sync. `--allow-out-of-order` skips the step 5 target-state confirmation.
+On success, after step 10 (not a progress step), the workflow records sync history: it writes `last_role` and `last_peer` on both machines to enable the out-of-order / target-state check next time. Skipped in `--dry-run`.
+
+With `--dry-run`, the workflow previews without writing state (no history update, no snapshots, no mutations). rsync `--dry-run` lists the exact files and deletions that would occur; deletions are recorded in the FULL-level log so you can audit what would be destroyed before committing to a live sync. `--allow-out-of-order` skips the out-of-order / target-state confirmation.
 
 ## Configuration
 

--- a/src/pcswitcher/jobs/base.py
+++ b/src/pcswitcher/jobs/base.py
@@ -182,7 +182,7 @@ class SyncJob(Job):
         for future non-rsync jobs without any orchestrator change.
 
         Called as a classmethod before job instances exist — the first-sync check
-        runs before Phase 4 job discovery.
+        runs before step 4 job discovery.
 
         Args:
             config: This job's configuration dict from config.yaml.

--- a/src/pcswitcher/orchestrator.py
+++ b/src/pcswitcher/orchestrator.py
@@ -215,7 +215,7 @@ class Orchestrator:
     def _create_job_context(self, config: dict[str, Any]) -> JobContext:
         """Create JobContext with current orchestrator state.
 
-        Must only be called after SSH connection is established (Phase 2+).
+        Must only be called after SSH connection is established (step 2+).
         """
         assert self._local_executor is not None
         assert self._remote_executor is not None
@@ -232,7 +232,7 @@ class Orchestrator:
             allow_first_sync=self._allow_first_sync,
             confirmer=self._confirmer,
             # Connection is always set when _create_job_context is called in
-            # production (Phase 2+), but unit tests mock executors without a
+            # production (step 2+), but unit tests mock executors without a
             # real connection, so fall back to None (JobContext accepts it).
             target_username=self._connection.username if self._connection is not None else None,
         )
@@ -269,10 +269,10 @@ class Orchestrator:
         # TerminalUI does not start the Live (start() is still called below),
         # so creating it early is safe.
         #
-        # Calculate total steps: 8 system phases + sync jobs + 1 post-snapshot
-        # System phases: 1=source lock, 2=SSH, 3=target lock, 4=validation,
+        # Calculate total steps: 8 system steps + sync jobs + 1 post-snapshot
+        # System steps: 1=source lock, 2=SSH, 3=target lock, 4=validation,
         # 5=disk check, 6=pre-snapshots, 7=install on target, 8=config sync
-        # Count only enabled jobs for the initial estimate; Phase 4 discovery may
+        # Count only enabled jobs for the initial estimate; step 4 discovery may
         # reduce this further (e.g. module not found), so we correct via
         # set_total_steps() after _discover_and_validate_jobs() returns.
         total_steps = 8 + sum(1 for enabled in self._config.sync_jobs.values() if enabled) + 1
@@ -323,28 +323,29 @@ class Orchestrator:
             )
 
         try:
-            # Phase 1: Acquire source lock
+            # Step 1: Acquire source lock
             self._logger.info("Acquiring source lock", extra={"job": "orchestrator", "host": "source"})
             await self._acquire_source_lock()
             self._ui.set_current_step(1, "Source lock")
 
-            # Phase 2: Establish SSH connection
+            # Step 2: Establish SSH connection
             self._logger.info("Connecting to target", extra={"job": "orchestrator", "host": "source"})
             await self._establish_connection()
             assert self._remote_executor is not None
             self._ui.set_current_step(2, "Connect to target")
 
-            # Phase 3: Acquire target lock
+            # Step 3: Acquire target lock
             self._logger.info("Acquiring target lock", extra={"job": "orchestrator", "host": "target"})
             await self._acquire_target_lock()
             self._ui.set_current_step(3, "Target lock")
 
-            # Topology out-of-order / target-state check (between Phase 3 and 4):
-            # runs after the target lock so we can read the target's sync-history over SSH.
+            # Topology out-of-order / target-state check (between steps 3 and 4, no
+            # progress step of its own): runs after the target lock so we can read
+            # the target's sync-history over SSH.
             if not await self._check_out_of_order():
                 raise SyncAbortedByUser("Sync aborted at the out-of-order / target-state check")
 
-            # Phase 4: Job discovery and validation
+            # Step 4: Job discovery and validation
             self._logger.info("Discovering and validating jobs", extra={"job": "orchestrator", "host": "source"})
             jobs = await self._discover_and_validate_jobs()
             # Correct the total now that we know the exact jobs that will run.
@@ -353,16 +354,16 @@ class Orchestrator:
             self._ui.set_total_steps(8 + len(jobs) + 1)
             self._ui.set_current_step(4, "Discover jobs")
 
-            # Phase 5: Disk space preflight check
+            # Step 5: Disk space preflight check
             await self._check_disk_space_preflight()
             self._ui.set_current_step(5, "Disk check")
 
-            # Phase 6: Pre-sync snapshots
+            # Step 6: Pre-sync snapshots
             self._logger.info("Creating pre-sync snapshots", extra={"job": "orchestrator", "host": "source"})
             await self._create_snapshots(SnapshotPhase.PRE)
             self._ui.set_current_step(6, "Pre-sync snapshots")
 
-            # Phase 7: Install/upgrade pc-switcher on target (after snapshots for rollback safety)
+            # Step 7: Install/upgrade pc-switcher on target (after snapshots for rollback safety)
             self._logger.info(
                 "Ensuring pc-switcher is installed on target",
                 extra={"job": "orchestrator", "host": "target"},
@@ -370,17 +371,17 @@ class Orchestrator:
             await self._install_on_target_job()
             self._ui.set_current_step(7, "Install on target")
 
-            # Phase 8: Sync config from source to target
+            # Step 8: Sync config from source to target
             self._logger.info("Syncing configuration to target", extra={"job": "orchestrator", "host": "target"})
             await self._sync_config_to_target()
             self._ui.set_current_step(8, "Sync config")
 
-            # Phase 9: Execute sync jobs with background monitoring
+            # Step 9: Execute sync jobs with background monitoring
             self._logger.info("Starting sync operations", extra={"job": "orchestrator", "host": "source"})
             job_results = await self._execute_jobs(jobs)
             session.job_results = job_results
 
-            # Phase 10: Post-sync snapshots
+            # Step 10: Post-sync snapshots
             self._logger.info("Creating post-sync snapshots", extra={"job": "orchestrator", "host": "source"})
             await self._create_snapshots(SnapshotPhase.POST)
             self._ui.set_current_step(8 + len(jobs) + 1, "Post-sync snapshots")
@@ -567,8 +568,8 @@ class Orchestrator:
 
         Convention: job_name == module_name (e.g., "dummy_success" → pcswitcher.jobs.dummy_success).
         Dynamically imports the module and scans its attributes for a SyncJob subclass whose
-        `name` ClassVar matches. Shared by `_discover_and_validate_jobs` (Phase 4 job discovery)
-        and `_first_sync_scopes` (pre-Phase-4 first-sync messaging) so the import/scan logic
+        `name` ClassVar matches. Shared by `_discover_and_validate_jobs` (step 4 job discovery)
+        and `_first_sync_scopes` (pre-step-4 first-sync messaging) so the import/scan logic
         lives in exactly one place.
 
         Returns:
@@ -608,7 +609,7 @@ class Orchestrator:
 
         Resolves every enabled job in `self._config.sync_jobs` (config order) to its SyncJob
         class via `_resolve_sync_job_class`, then calls `describe_first_sync_scope()` on each —
-        this runs before Phase 4 job discovery, so classes (not instances) are used. Jobs that
+        this runs before step 4 job discovery, so classes (not instances) are used. Jobs that
         return None (no overwrite scope, or nothing in scope for their config) contribute
         nothing; the orchestrator's warning falls back to generic phrasing when this is empty.
         """

--- a/src/pcswitcher/ui.py
+++ b/src/pcswitcher/ui.py
@@ -356,7 +356,7 @@ class TerminalUI:
     def set_total_steps(self, total: int) -> None:
         """Correct the total step count once the actual number of jobs is known.
 
-        Called by the orchestrator after Phase 4 job discovery to replace the
+        Called by the orchestrator after step 4 job discovery to replace the
         initial estimate with the exact count of enabled, discoverable jobs.
         Refreshes the live render immediately so the display reflects the correction.
 


### PR DESCRIPTION
Fixes #186.

## Problem
Three numbering schemes for the sync sequence disagreed:
- **README**: 13 numbered steps (included the pre-orchestrator config load, the out-of-order check, and record-history).
- **Code `# Phase N` comments**: 1–10 (orchestrator steps only).
- **User-visible UI counter**: `Step N/10` (e.g. `Step 7/10 — Install on target`).

The code comments and the UI counter already agreed; only the README's 13-step scheme diverged.

## Fix
Align everything on the code/UI numbering (1–10, what the live UI actually shows):
- Renumber the README list to 1–10. The three items that are not progress steps (config load, out-of-order check, record sync history) become clearly-marked unnumbered notes, and the stale `step 5` cross-references are dropped.
- Rename the sync-sequence `# Phase N` comments to `# Step N` in `orchestrator.py` (plus the `Phase 4`/`step 4` docstring references in `ui.py` and `jobs/base.py`) so code terminology matches the UI and README.

The distinct *validation* `Phase 1/2/3` (schema/config/system-state) and *project-roadmap* `Phase 1` references are left unchanged — different concepts.

## Verification
`ruff`, `basedpyright`, and the UI + orchestrator unit suites (113 tests) pass. Changes are comments/docs only — no runtime behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVcY6HkttoNvKDJpCBDJq7