### PR TITLE
refactor(folder_sync): name the rsync passes for what they do (#198)

### DIFF
--- a/docs/adr/adr-018-selective-vscode-state-sync.md
+++ b/docs/adr/adr-018-selective-vscode-state-sync.md
@@ -26,7 +26,7 @@ INVARIANT: the set of files `folder_sync` excludes from the mirror is EXACTLY th
 ## Decision
 - Add a toggleable `vscode_state_sync` `SyncJob` (default on) that runs after `folder_sync` and performs the selective SQLite merge above.
 - Handle these VS Code state DBs outside the `folder_sync` mirror (exclude them non-overridably; merge them in the dedicated job), so the target's live DB still holds its own secrets at merge time and no pre-step is needed. Keeping the VS Code specifics out of the generic mirror was a deliberate goal — `folder_sync` only translates the paths it is handed.
-- Rejected: injecting a filter file into the user's config tree (invasive; collides with the user's `.pcswitcher-filter` surface and trips the seeding-pass detection); a btrfs-snapshot dependency (couples a functional feature to the rollback subsystem).
+- Rejected: injecting a filter file into the user's config tree (invasive; collides with the user's `.pcswitcher-filter` surface and trips the copy-pass detection); a btrfs-snapshot dependency (couples a functional feature to the rollback subsystem).
 
 ## Consequences
 **Positive**:

--- a/src/pcswitcher/jobs/folder_sync.py
+++ b/src/pcswitcher/jobs/folder_sync.py
@@ -56,22 +56,26 @@ from pcswitcher.models import ConfigError, FirstSyncScope, Host, LogLevel, Progr
 # degraded scanned-count path for it regardless.
 _PROGRESS2_RE = re.compile(r"(\d+[\d,.]*[KMGT]?)\s+(\d+)%\s+\S+\s+\S+\s+\(xfr#(\d+),\s*(ir|to)-chk=(\d+)/(\d+)\)")
 
-# The two rsync passes a folder can run (see `execute`): the no-delete pass that ships
-# per-directory filter files, and the deleting mirror.  Both share that folder's
-# progress bar (tracked by path) and only rename it, so the run shows one bar per
-# configured folder — finished folders stay at 100%.
-PASS_PREP = "prep"
-PASS_FULL = "full"
+# How a folder's rsync work is split (see `execute`).  In the steady state one pass
+# both transfers and deletes (PASS_MIRROR).  When per-directory filter files must reach
+# the target first, the work splits in two: a full no-delete copy (PASS_COPY) followed by
+# the deleting mirror (PASS_DELETE), which by then has only deletions left to do.
+# All passes of a folder share that folder's progress bar (tracked by path) and only
+# rename it, so the run shows one bar per configured folder — finished folders stay
+# at 100%.
+PASS_COPY = "copy"
+PASS_DELETE = "delete"
+PASS_MIRROR = "mirror"
 
 
 def _pass_display(path: str, label: str) -> str:
     """Name a pass for the TUI.
 
-    The deleting mirror is the pass that always runs, so it shows the bare folder path;
-    only the optional seeding pass is qualified, so its bar cannot be mistaken for the
-    real sync of that folder.
+    A lone pass does the folder's whole job, so it needs no qualifier and shows the bare
+    path.  When the work is split across two passes each half is named, so neither bar
+    can be mistaken for the complete sync of that folder.
     """
-    return path if label == PASS_FULL else f"{path} ({label})"
+    return path if label == PASS_MIRROR else f"{path} ({label})"
 
 
 # pc-switcher's own runtime STATE lives under the invoking user's home and must
@@ -406,9 +410,8 @@ class FolderSyncJob(SyncJob):
     def _transport_args(self) -> list[str]:
         """Build the rsync `-e <ssh>` transport and `--rsync-path='sudo rsync'` args.
 
-        Shared by the main mirror (`_build_rsync_cmd`) and the filter pre-seed pass
-        (`_build_preseed_cmd`) so both use identical SSH credentials and target-side
-        sudo elevation.
+        Used by every pass `_build_rsync_cmd` produces, so all of them use identical SSH
+        credentials and target-side sudo elevation.
 
         SSH transport note: `sudo -E rsync` runs rsync as root, and the ssh it spawns
         also runs as root.  OpenSSH resolves `~/.ssh` from the running uid's passwd
@@ -446,15 +449,15 @@ class FolderSyncJob(SyncJob):
         # Root on target via passwordless sudo scoped to /usr/bin/rsync (D-05).
         return [f"-e {shlex.quote(ssh_cmd)}", f"--rsync-path={shlex.quote('sudo rsync')}"]
 
-    async def _needs_seeding_pass(self, folder: FolderEntry) -> bool:
-        """Whether a no-delete seeding pass must run before the deleting mirror.
+    async def _needs_copy_pass(self, folder: FolderEntry) -> bool:
+        """Whether a no-delete copy pass must run before the deleting mirror.
 
         A dir-merge rule is read from the *receiver* during the delete scan, so the
         deleting mirror protects the target correctly only when every source
         `.pcswitcher-filter` is already present and byte-identical on the target.  In
         the steady state that already holds — filter files sync like any other file —
-        so a single pass is safe and the whole tree is walked only once.  A seeding
-        pass is needed only when a per-directory filter was added or changed on the
+        so a single pass is safe and the whole tree is walked only once.  The split into
+        two passes is needed only when a per-directory filter was added or changed on the
         source (or on a first sync): then the source's filter files are not yet
         reflected on the target and the mirror must align them first.
 
@@ -464,7 +467,7 @@ class FolderSyncJob(SyncJob):
         default config uses only the central `filter_file`), skipping the target
         round-trip.  Runs as root, like the mirror, so filter files under directories
         the invoking user cannot read are still seen and hashed.  Target-only extra
-        filter files do not force a seeding pass (they only ever add protection).
+        filter files do not force a copy pass (they only ever add protection).
         """
         path = shlex.quote(folder.path.rstrip("/") or "/")
         manifest_cmd = f"sudo find {path} -name .pcswitcher-filter -exec sha256sum {{}} +"
@@ -487,7 +490,7 @@ class FolderSyncJob(SyncJob):
           normal-user SSH connection (D-05); root SSH login stays disabled.
         - Uses the D-13 flag baseline: -aAXHS + --numeric-ids + --delete.
         - Adds --dry-run only when `dry_run` is True (D-12).
-        - Omits --delete when `delete` is False: `execute` runs a no-delete seeding
+        - Omits --delete when `delete` is False: `execute` runs a no-delete copy
           pass first (when the tree has per-directory filters) so every source
           `.pcswitcher-filter` reaches the target before the deleting mirror — a
           dir-merge rule only protects the target once the filter file is on the
@@ -587,7 +590,8 @@ class FolderSyncJob(SyncJob):
         Args:
             chunks: Async byte-chunk source (e.g. `proc.read_stdout_chunks()`).
             folder: The folder being synced (used for log context).
-            label: Pass name shown next to the folder in the TUI (`prep` / `full`).
+            label: Pass name shown next to the folder in the TUI (`copy` / `delete` /
+                `mirror`; see `_pass_display`).
 
         Returns:
             Tuple of (files_transferred, bytes_transferred, files_deleted).
@@ -684,9 +688,8 @@ class FolderSyncJob(SyncJob):
         Spawns rsync as an async subprocess (ADR-005 — no blocking calls), streams
         stdout through `_stream_rsync` for TUI progress (D-15) and per-file FULL logs
         (D-16), then checks the exit code.  Returns the pass's
-        (files_transferred, bytes_transferred, files_deleted).  Shared by the no-delete
-        seeding pass and the deleting mirror in `execute`, which name themselves via
-        `label` (`prep` / `full`).
+        (files_transferred, bytes_transferred, files_deleted).  Shared by every pass
+        `execute` runs, which name themselves via `label` (`copy` / `delete` / `mirror`).
         """
         proc = await self.source.start_process(cmd)
         files_transferred, bytes_transferred, files_deleted = await self._stream_rsync(
@@ -713,18 +716,22 @@ class FolderSyncJob(SyncJob):
 
         For each active folder (D-10):
         1. When this is a real sync and the source's per-directory `.pcswitcher-filter`
-           files are not already reflected on the target (`_needs_seeding_pass`), runs
-           a seeding pass first — the same mirror WITHOUT `--delete` — so every source
+           files are not already reflected on the target (`_needs_copy_pass`), runs a
+           copy pass first — the same mirror WITHOUT `--delete` — so every source
            `.pcswitcher-filter` reaches the target before the deleting mirror.  A
            dir-merge rule only protects the target once the filter file is on the
            receiver, so without this the deleting mirror would remove (not protect)
-           the files a per-dir rule names.  Both passes apply the identical filter
-           chain, so the central `filter_file` and per-directory rules are respected
-           exactly.  Skipped in dry-run (must not write to the target, D-12), which
-           makes the dry-run deletion preview pessimistic for per-dir-protected paths
-           (the safe direction), and skipped when the per-directory filters already
-           match on both ends (the steady state — no seeding is needed).
+           the files a per-dir rule names.  This pass is not limited to filter files:
+           it is the full transfer, so on a split run it moves all the data and the
+           mirror that follows is left with only deletions.  Both passes apply the
+           identical filter chain, so the central `filter_file` and per-directory rules
+           are respected exactly.  Skipped in dry-run (must not write to the target,
+           D-12), which makes the dry-run deletion preview pessimistic for
+           per-dir-protected paths (the safe direction), and skipped when the
+           per-directory filters already match on both ends (the steady state).
         2. Runs the deleting mirror (D-13 baseline, D-11 filters, D-12 dry-run toggle).
+           Named `delete` when a copy pass preceded it and `mirror` when it ran alone
+           and therefore did both halves of the job.
         3. On non-zero exit from either pass, logs CRITICAL and raises RuntimeError.
         """
         folders = self._active_folders()
@@ -738,27 +745,30 @@ class FolderSyncJob(SyncJob):
                 session_id=self.context.session_id,
             )
 
-            seed_files = 0
-            seed_bytes = 0
-            if not self.context.dry_run and await self._needs_seeding_pass(folder):
+            copy_files = 0
+            copy_bytes = 0
+            split = not self.context.dry_run and await self._needs_copy_pass(folder)
+            if split:
                 self._log(
                     Host.SOURCE,
                     LogLevel.FULL,
-                    f"Seeding per-directory filter files for {folder.path!r} (no-delete pass)",
+                    f"Copy pass for {folder.path!r} (no-delete), to place per-directory filter files",
                 )
-                seed_files, seed_bytes, _ = await self._run_rsync_pass(
-                    self._build_rsync_cmd(folder, dry_run=False, delete=False), folder, PASS_PREP
+                copy_files, copy_bytes, _ = await self._run_rsync_pass(
+                    self._build_rsync_cmd(folder, dry_run=False, delete=False), folder, PASS_COPY
                 )
 
             # Deleting mirror (or, in dry-run, the read-only preview).
             mirror_files, mirror_bytes, files_deleted = await self._run_rsync_pass(
-                self._build_rsync_cmd(folder, self.context.dry_run, delete=True), folder, PASS_FULL
+                self._build_rsync_cmd(folder, self.context.dry_run, delete=True),
+                folder,
+                PASS_DELETE if split else PASS_MIRROR,
             )
 
-            # On a seeding run the bulk transfer happened in the first pass and the
-            # mirror transfers ~nothing; sum so the summary reflects the real work.
-            files_transferred = seed_files + mirror_files
-            bytes_transferred = seed_bytes + mirror_bytes
+            # On a split run the bulk transfer happened in the copy pass and the mirror
+            # transfers ~nothing; sum so the summary reflects the real work.
+            files_transferred = copy_files + mirror_files
+            bytes_transferred = copy_bytes + mirror_bytes
 
             # Per-folder summary (D-16). Human-readable size at INFO; exact byte
             # count kept at DEBUG for precise diagnostics (#189).

--- a/tests/integration/test_end_to_end_sync.py
+++ b/tests/integration/test_end_to_end_sync.py
@@ -325,9 +325,9 @@ _FILTER_SRC_PERDIR: dict[str, str] = {
 # first sync. A dir-merge rule is read per-side, so a per-directory exclude protects a
 # pre-existing target file from --delete only once the filter file is on the receiver
 # (verified against rsync 3.2.7). folder_sync closes that gap: because the source filter
-# files are not yet on the target (_needs_seeding_pass detects the mismatch), execute()
-# runs the mirror WITHOUT --delete first to seed them, then the deleting mirror — so the
-# per-dir survivors below are protected on this first sync. That seeding pass is exactly
+# files are not yet on the target (_needs_copy_pass detects the mismatch), execute()
+# runs the mirror WITHOUT --delete first to place them, then the deleting mirror — so the
+# per-dir survivors below are protected on this first sync. That copy pass is exactly
 # what this scenario exercises end-to-end.
 _FILTER_TGT: dict[str, str] = {
     f"{_FILTER_TREE}/synced/overwrite_me.txt": "old",  # included, differing size → overwritten by source

--- a/tests/local_rsync/test_folder_sync_filters.py
+++ b/tests/local_rsync/test_folder_sync_filters.py
@@ -144,14 +144,14 @@ class TestGlobalFirstEnforcement:
         assert "proj/secret.env" not in transferred
 
 
-class TestSeedingPassProtectsTargetOnFirstSync:
+class TestCopyPassProtectsTargetOnFirstSync:
     """A per-directory exclude protects a pre-existing target file on the FIRST sync — when the
-    target does not yet have the `.pcswitcher-filter` — via folder_sync's no-delete seeding pass.
+    target does not yet have the `.pcswitcher-filter` — via folder_sync's no-delete copy pass.
 
     A dir-merge rule is read per-side, so without the filter file on the receiver the `--delete`
     mirror deletes (not protects) the target file the rule names, and an excluded-on-source file
     is never sent, so an update collapses into a deletion too. folder_sync runs the same mirror
-    WITHOUT `--delete` first (execute() -> _build_rsync_cmd(delete=False)), which seeds every
+    WITHOUT `--delete` first (execute() -> _build_rsync_cmd(delete=False)), which places every
     `.pcswitcher-filter` onto the target while respecting the full filter chain; the deleting pass
     then protects correctly. These tests reproduce both passes with real rsync (no --dry-run) and
     pin the single-pass bug plus the two-pass fix for the delete AND update cases.
@@ -159,7 +159,7 @@ class TestSeedingPassProtectsTargetOnFirstSync:
 
     @staticmethod
     def _no_delete_pass(src: Path, dst: Path) -> None:
-        # Mirrors _build_rsync_cmd(delete=False): full filter chain, no --delete (seeds filter files).
+        # Mirrors _build_rsync_cmd(delete=False): full filter chain, no --delete (places filter files).
         subprocess.run(
             ["rsync", "-a", "--filter=dir-merge /.pcswitcher-filter", f"{src}/", f"{dst}/"],
             check=True,
@@ -178,7 +178,7 @@ class TestSeedingPassProtectsTargetOnFirstSync:
         )
 
     def test_single_pass_deletes_the_excluded_target_file(self, tmp_path: Path) -> None:
-        """Without the seeding pass, the deleting mirror DELETES the rule-excluded target file (the bug)."""
+        """Without the copy pass, the deleting mirror DELETES the rule-excluded target file (the bug)."""
         src = tmp_path / "src"
         dst = tmp_path / "dst"
         _write(src / "proj/.pcswitcher-filter", "- secret.env\n")
@@ -189,7 +189,7 @@ class TestSeedingPassProtectsTargetOnFirstSync:
     def test_single_pass_protects_when_filter_already_on_target(self, tmp_path: Path) -> None:
         """Steady state: with the .pcswitcher-filter already on the target, ONE deleting pass protects it.
 
-        This is exactly what _needs_seeding_pass relies on to skip the seeding pass when the source
+        This is exactly what _needs_copy_pass relies on to skip the copy pass when the source
         and target filter files already match — the common case after a first successful sync.
         """
         src = tmp_path / "src"
@@ -197,11 +197,11 @@ class TestSeedingPassProtectsTargetOnFirstSync:
         _write(src / "proj/.pcswitcher-filter", "- secret.env\n")
         _write(dst / "proj/.pcswitcher-filter", "- secret.env\n")  # already present on the target
         _write(dst / "proj/secret.env", "tgt-only-secret")
-        self._mirror(src, dst)  # single --delete pass, no seeding
+        self._mirror(src, dst)  # single --delete pass, no preceding copy pass
         assert (dst / "proj/secret.env").read_text() == "tgt-only-secret"
 
     def test_two_pass_protects_a_target_only_excluded_file(self, tmp_path: Path) -> None:
-        """delete case: seeding pass then mirror keeps a target-only rule-excluded file."""
+        """delete case: copy pass then mirror keeps a target-only rule-excluded file."""
         src = tmp_path / "src"
         dst = tmp_path / "dst"
         _write(src / "proj/.pcswitcher-filter", "- secret.env\n")
@@ -216,7 +216,7 @@ class TestSeedingPassProtectsTargetOnFirstSync:
     def test_two_pass_does_not_overwrite_or_delete_an_excluded_update(self, tmp_path: Path) -> None:
         """update case: source has a rule-excluded file with NEW content, target has OLD; target keeps OLD.
 
-        This is the case that fails in a single pass (the target file is deleted). The seeding pass
+        This is the case that fails in a single pass (the target file is deleted). The copy pass
         puts the filter onto the target first, so the deleting mirror neither overwrites nor deletes it.
         """
         src = tmp_path / "src"

--- a/tests/unit/jobs/test_folder_sync.py
+++ b/tests/unit/jobs/test_folder_sync.py
@@ -18,7 +18,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from pcswitcher.jobs import JobContext
-from pcswitcher.jobs.folder_sync import PASS_FULL, PASS_PREP, FolderEntry, FolderSyncJob
+from pcswitcher.jobs.folder_sync import PASS_COPY, PASS_DELETE, PASS_MIRROR, FolderEntry, FolderSyncJob
 from pcswitcher.jobs.vscode_state_sync import VSCODE_STATE_DB_RELPATHS
 from pcswitcher.models import CommandResult, FirstSyncScope, Host, LogLevel, ProgressUpdate
 
@@ -538,9 +538,9 @@ class TestBuildRsyncCmd:
 
 
 class TestBuildRsyncCmdDeleteToggle:
-    """_build_rsync_cmd's `delete` flag drives the no-delete seeding pass vs the deleting mirror.
+    """_build_rsync_cmd's `delete` flag drives the no-delete copy pass vs the deleting mirror.
 
-    The seeding pass (delete=False) is the same command minus `--delete`, so it applies the
+    The copy pass (delete=False) is the same command minus `--delete`, so it applies the
     identical filter chain (central merge + dir-merge) and thus respects every filter exactly.
     """
 
@@ -556,10 +556,10 @@ class TestBuildRsyncCmdDeleteToggle:
         assert "--delete" in self._build(delete=True)
 
     def test_delete_omitted_when_false(self) -> None:
-        """The seeding pass omits --delete (it seeds without removing anything)."""
+        """The copy pass omits --delete (it transfers without removing anything)."""
         assert "--delete" not in self._build(delete=False)
 
-    def test_seeding_pass_keeps_the_full_filter_chain(self) -> None:
+    def test_copy_pass_keeps_the_full_filter_chain(self) -> None:
         """delete=False still emits the central merge and dir-merge, so filters are respected."""
         cmd = self._build(delete=False)
         assert "merge /abs/home.filter" in cmd
@@ -816,7 +816,7 @@ class TestStreamRsync:
             for chunk in chunks:
                 yield chunk
 
-        result = await job._stream_rsync(gen_chunks(), folder, PASS_FULL)
+        result = await job._stream_rsync(gen_chunks(), folder, PASS_MIRROR)
         return result, log_calls, progress_calls
 
     async def test_pass_opens_with_file_list_heartbeat(self) -> None:
@@ -917,15 +917,15 @@ class TestStreamRsync:
             yield b"9.53G 40% 300.00MB/s 0:00:10 (xfr#10, to-chk=60/100)\r"
             yield b"9.53G 80% 300.00MB/s 0:00:05 (xfr#80, to-chk=20/100)\r"
 
-        await job._stream_rsync(gen_chunks(), FolderEntry(path="/home"), PASS_PREP)
-        await job._stream_rsync(gen_chunks(), FolderEntry(path="/home"), PASS_FULL)
+        await job._stream_rsync(gen_chunks(), FolderEntry(path="/home"), PASS_COPY)
+        await job._stream_rsync(gen_chunks(), FolderEntry(path="/home"), PASS_DELETE)
 
         percents = [u.percent for u in progress_calls if u.percent is not None]
         assert percents == [40, 80, 40, 80], "second pass must restart the bar, not continue the first"
-        # Each pass opens with its own heartbeat, so the first three updates are the prep pass.
-        # The seeding pass is qualified; the mirror shows the bare folder path.
-        assert all(u.item is not None and u.item.startswith(f"/home ({PASS_PREP})") for u in progress_calls[:3])
-        assert all(u.item is not None and u.item.startswith("/home —") for u in progress_calls[3:])
+        # Each pass opens with its own heartbeat, so the first three updates are the copy pass.
+        # Both halves of a split run are qualified, so neither reads as the whole sync.
+        assert all(u.item is not None and u.item.startswith(f"/home ({PASS_COPY})") for u in progress_calls[:3])
+        assert all(u.item is not None and u.item.startswith(f"/home ({PASS_DELETE})") for u in progress_calls[3:])
 
     async def test_per_file_line_logged_at_full(self) -> None:
         """An --out-format per-file line is logged at LogLevel.FULL."""
@@ -1033,11 +1033,11 @@ class TestStreamRsync:
 
 
 @pytest.mark.asyncio
-class TestNeedsSeedingPass:
-    """_needs_seeding_pass compares source vs target `.pcswitcher-filter` content hashes.
+class TestNeedsCopyPass:
+    """_needs_copy_pass compares source vs target `.pcswitcher-filter` content hashes.
 
     Single pass is safe iff every source filter file is present & identical on the target
-    (target-only extras are fine); otherwise a seeding pass is needed to align them.
+    (target-only extras are fine); otherwise a copy pass is needed to align them first.
     """
 
     def _job(self, source_out: str, target_out: str) -> tuple[FolderSyncJob, AsyncMock]:
@@ -1050,31 +1050,31 @@ class TestNeedsSeedingPass:
     async def test_no_source_filters_skips_target_round_trip(self) -> None:
         """No source filter files -> single pass, and the target is never queried."""
         job, target_rc = self._job(source_out="", target_out="ignored")
-        assert await job._needs_seeding_pass(FolderEntry(path="/home")) is False
+        assert await job._needs_copy_pass(FolderEntry(path="/home")) is False
         target_rc.assert_not_called()
 
-    async def test_identical_manifests_need_no_seeding(self) -> None:
+    async def test_identical_manifests_need_no_copy_pass(self) -> None:
         line = "abc123  /home/alice/proj/.pcswitcher-filter"
         job, _ = self._job(source_out=line + "\n", target_out=line + "\n")
-        assert await job._needs_seeding_pass(FolderEntry(path="/home")) is False
+        assert await job._needs_copy_pass(FolderEntry(path="/home")) is False
 
-    async def test_source_filter_absent_on_target_needs_seeding(self) -> None:
+    async def test_source_filter_absent_on_target_needs_copy_pass(self) -> None:
         job, _ = self._job(source_out="abc  /home/a/.pcswitcher-filter\n", target_out="")
-        assert await job._needs_seeding_pass(FolderEntry(path="/home")) is True
+        assert await job._needs_copy_pass(FolderEntry(path="/home")) is True
 
-    async def test_source_filter_content_differs_needs_seeding(self) -> None:
-        """Same path, different hash (edited filter) -> different line -> not a subset -> seed."""
+    async def test_source_filter_content_differs_needs_copy_pass(self) -> None:
+        """Same path, different hash (edited filter) -> different line -> not a subset -> copy pass."""
         job, _ = self._job(
             source_out="NEWHASH  /home/a/.pcswitcher-filter\n",
             target_out="OLDHASH  /home/a/.pcswitcher-filter\n",
         )
-        assert await job._needs_seeding_pass(FolderEntry(path="/home")) is True
+        assert await job._needs_copy_pass(FolderEntry(path="/home")) is True
 
-    async def test_target_only_extra_filters_need_no_seeding(self) -> None:
-        """A filter present only on the target never forces a seeding pass (it only adds protection)."""
+    async def test_target_only_extra_filters_need_no_copy_pass(self) -> None:
+        """A filter present only on the target never forces a copy pass (it only adds protection)."""
         line = "abc  /home/a/.pcswitcher-filter"
         job, _ = self._job(source_out=line + "\n", target_out=line + "\nxyz  /home/b/.pcswitcher-filter\n")
-        assert await job._needs_seeding_pass(FolderEntry(path="/home")) is False
+        assert await job._needs_copy_pass(FolderEntry(path="/home")) is False
 
 
 @pytest.mark.asyncio
@@ -1093,8 +1093,8 @@ class TestExecuteDryRun:
         called_cmd: str = ctx.source.start_process.call_args[0][0]
         assert "--dry-run" in called_cmd
 
-    async def test_dry_run_skips_seeding_and_the_manifest_check(self) -> None:
-        """Dry-run must not write to the target: neither the manifest check nor the seeding pass runs."""
+    async def test_dry_run_skips_the_copy_pass_and_the_manifest_check(self) -> None:
+        """Dry-run must not write to the target: neither the manifest check nor the copy pass runs."""
         ctx = make_context(dry_run=True)
         # Even if the manifests would differ, dry-run short-circuits before the check.
         ctx.source.run_command = AsyncMock(
@@ -1149,11 +1149,11 @@ class TestExecuteNormalMode:
         # A CRITICAL-level record must have been emitted
         assert any(r.levelno == LogLevel.CRITICAL for r in caplog.records)
 
-    async def test_seeding_pass_runs_before_the_mirror_when_filters_differ(self) -> None:
-        """When a source per-dir filter isn't yet on the target, a no-delete seeding pass precedes the mirror.
+    async def test_copy_pass_runs_before_the_mirror_when_filters_differ(self) -> None:
+        """When a source per-dir filter isn't yet on the target, a no-delete copy pass precedes the mirror.
 
         Both passes carry the same dir-merge filter, so per-directory (and central) rules are
-        respected in each — the seeding pass just omits --delete so it can put the filter files
+        respected in each — the copy pass just omits --delete so it can put the filter files
         onto the target before the deleting mirror runs.
         """
         ctx = make_context()
@@ -1166,15 +1166,15 @@ class TestExecuteNormalMode:
         job = FolderSyncJob(ctx)
         await job.execute()
 
-        assert ctx.source.start_process.call_count == 2, "expected a seeding pass then the mirror"
-        seed_cmd = ctx.source.start_process.call_args_list[0].args[0]
+        assert ctx.source.start_process.call_count == 2, "expected a copy pass then the mirror"
+        copy_cmd = ctx.source.start_process.call_args_list[0].args[0]
         mirror_cmd = ctx.source.start_process.call_args_list[1].args[0]
-        assert "--delete" not in seed_cmd, "the seeding pass must not delete"
+        assert "--delete" not in copy_cmd, "the copy pass must not delete"
         assert "--delete" in mirror_cmd, "the mirror pass deletes"
-        assert "dir-merge /.pcswitcher-filter" in seed_cmd
+        assert "dir-merge /.pcswitcher-filter" in copy_cmd
         assert "dir-merge /.pcswitcher-filter" in mirror_cmd
 
-    async def test_seeding_pass_skipped_when_no_source_filters(self) -> None:
+    async def test_copy_pass_skipped_when_no_source_filters(self) -> None:
         """With no .pcswitcher-filter on the source, only the single deleting mirror runs (common case)."""
         ctx = make_context()
         ctx.source.run_command = AsyncMock(return_value=CommandResult(exit_code=0, stdout="", stderr=""))
@@ -1189,16 +1189,16 @@ class TestExecuteNormalMode:
         assert "--delete" in ctx.source.start_process.call_args[0][0]
         target_rc.assert_not_called()  # short-circuit: no target manifest round-trip
 
-    async def test_seeding_pass_failure_aborts_before_the_mirror(self) -> None:
-        """A non-zero exit in the seeding pass raises RuntimeError; the deleting mirror never runs."""
+    async def test_copy_pass_failure_aborts_before_the_mirror(self) -> None:
+        """A non-zero exit in the copy pass raises RuntimeError; the deleting mirror never runs."""
         ctx = make_context()
         ctx.source.run_command = AsyncMock(
             return_value=CommandResult(exit_code=0, stdout="hash  /home/alice/.pcswitcher-filter\n", stderr="")
         )
-        # The first (seeding) pass fails.
+        # The first (copy) pass fails.
         ctx.source.start_process = AsyncMock(return_value=make_fake_process(exit_code=23, stderr="boom"))
 
         job = FolderSyncJob(ctx)
         with pytest.raises(RuntimeError):
             await job.execute()
-        assert ctx.source.start_process.call_count == 1, "mirror must not run after a failed seeding pass"
+        assert ctx.source.start_process.call_count == 1, "mirror must not run after a failed copy pass"

--- a/tests/unit/jobs/test_folder_sync_deletion_log.py
+++ b/tests/unit/jobs/test_folder_sync_deletion_log.py
@@ -24,7 +24,7 @@ import pytest
 
 from pcswitcher.config import LogConfig
 from pcswitcher.jobs.context import JobContext
-from pcswitcher.jobs.folder_sync import PASS_FULL, FolderEntry, FolderSyncJob
+from pcswitcher.jobs.folder_sync import PASS_MIRROR, FolderEntry, FolderSyncJob
 from pcswitcher.logger import setup_logging
 from pcswitcher.models import LogLevel
 
@@ -79,7 +79,7 @@ async def _drive_stream_rsync_to_log(log_file: Path, *, dry_run: bool) -> None:
         ctx = _make_context(dry_run=dry_run)
         job = FolderSyncJob(ctx)
         folder = FolderEntry(path="/home")
-        await job._stream_rsync(_deletion_chunks(), folder, PASS_FULL)
+        await job._stream_rsync(_deletion_chunks(), folder, PASS_MIRROR)
     finally:
         # Stop listener first so the QueueListener drains and FileHandler flushes.
         listener.stop()

--- a/tests/unit/ui/test_terminal_ui.py
+++ b/tests/unit/ui/test_terminal_ui.py
@@ -152,14 +152,14 @@ def test_track_gives_each_unit_of_work_its_own_persistent_bar() -> None:
     ui = TerminalUI(console=console, max_log_lines=5, total_steps=None)
 
     job = "folder_sync"
-    ui.update_job_progress(job, ProgressUpdate(percent=100, item="/home (prep)", track="/home"))
-    ui.update_job_progress(job, ProgressUpdate(percent=100, item="/home (full)", track="/home"))
-    ui.update_job_progress(job, ProgressUpdate(percent=30, item="/root (full)", track="/root"))
+    ui.update_job_progress(job, ProgressUpdate(percent=100, item="/home (copy)", track="/home"))
+    ui.update_job_progress(job, ProgressUpdate(percent=100, item="/home (delete)", track="/home"))
+    ui.update_job_progress(job, ProgressUpdate(percent=30, item="/root", track="/root"))
 
     assert len(ui._job_tasks) == 2, "one bar per folder, shared by that folder's passes"
     home, root = (ui._progress._tasks[t] for t in ui._job_tasks.values())
     assert home.completed == 100, "a finished folder must stay at its final value"
-    assert home.description.endswith("/home (full)")
+    assert home.description.endswith("/home (delete)")
     assert root.completed == 30
 
 


### PR DESCRIPTION
## Problem

The TUI labelled the first rsync pass `(prep)` and left the second bare, which reads as "the first pass prepares, the second syncs". It is the other way round: the first pass is built by `_build_rsync_cmd(delete=False)` — the identical full mirror minus `--delete` — so it transfers the entire tree, and the deleting mirror that follows has only deletions left to do. Observed live: multiple GB moved under `(prep)`, then the unlabelled pass finished instantly.

## Change

Naming only, no behaviour change.

The split into two passes is conditional (it happens only when the source's per-directory `.pcswitcher-filter` files are not yet on the target), so a two-name scheme would mislabel the common single-pass run. Three labels instead:

| Case | Pass | Constant | TUI |
|---|---|---|---|
| Steady state | one pass, transfers + deletes | `PASS_MIRROR` | `/home` |
| Split run | 1st: full copy, no delete | `PASS_COPY` | `/home (copy)` |
| | 2nd: deletions in practice | `PASS_DELETE` | `/home (delete)` |

A lone pass does the folder's whole job so it stays unqualified; when the work is split, both halves are named so neither bar can be mistaken for the complete sync.

Also: `_needs_seeding_pass` → `_needs_copy_pass`, "seeding pass" → "copy pass" throughout docstrings and tests, and `execute`'s docstring now states outright that the copy pass is not limited to filter files.

## Not in scope

The copy pass still transfers the whole tree when its stated purpose only needs the `.pcswitcher-filter` files. Narrowing it is a separate change.

## Verification

`ruff check` / `ruff format` / `basedpyright` clean; `pytest` 705 passed; `tests/local_rsync` 8 passed. Integration tests not run locally — CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KYNNCrjxTXE55Q3EQ9TzPB