### PR TITLE
fix(vscode_state_sync): preserve auth session pointers, not just secrets

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -212,7 +212,7 @@ Otherwise it matches gitignore (basenames, a trailing `/` for directories, `*`/`
 
 Two groups are always excluded from the mirror and cannot be re-included by any filter rule:
 - pc-switcher's own runtime state — `~/.local/share/pc-switcher/` (lock file, sync history, logs) — so a sync never disturbs the target's sync state or per-machine logs (ADR-017); its install itself (uv tool venv and `~/.local/bin` shim) mirrors like any other file, so it stays consistent with the interpreter it depends on.
-- If `vscode_state_sync` is enabled, the VS Code state DBs (`state.vscdb` and `state.vscdb.backup` for Code, Antigravity, Cursor, VSCodium, plus the install-shared `~/.vscode-shared/sharedStorage/`) — these are handed to `vscode_state_sync`, which merges them selectively so machine-bound `secret://` rows are never clobbered (ADR-018; see [`vscode_state_sync`](#vscode_state_sync) below).
+- If `vscode_state_sync` is enabled, the VS Code state DBs (`state.vscdb` and `state.vscdb.backup` for Code, Antigravity, Cursor, VSCodium, plus the install-shared `~/.vscode-shared/sharedStorage/`) — these are handed to `vscode_state_sync`, which merges them selectively so machine-bound account rows are never clobbered (ADR-018; see [`vscode_state_sync`](#vscode_state_sync) below).
 
 ## `vscode_state_sync`
 
@@ -222,9 +222,13 @@ Selectively syncs each VS Code-based editor's (VS Code and its forks) global `st
 vscode_state_sync: true          # enable in sync_jobs (default true)
 ```
 
-The job mirrors every key from the source **except** the machine-bound `secret://` keys, whose value the **target keeps** — so machine-bound secrets stay local. Non-matched keys take the source's value; keys present only on the target and not matched are dropped (the same fidelity as the `folder_sync` `--delete` mirror).
+The job mirrors every key from the source **except** the machine-bound account keys, whose value the **target keeps**. Two kinds are preserved: the `secret://` SecretStorage blobs, and the auth session preferences that point into them (`userDataSyncAccountPreference` and the per-extension `<extensionId>-<providerId>-<scopes>` keys). The pointers matter as much as the blobs — their value is a session id regenerated on every sign-in, so mirroring one hands the target a session it does not hold, and VS Code asks you to sign in again. Non-matched keys take the source's value; keys present only on the target and not matched are dropped (the same fidelity as the `folder_sync` `--delete` mirror).
 
-The job has no settings: the editor list, DB layout, and the preserved-key namespace (`secret://`, VS Code's SecretStorage prefix) are VS Code internals owned by the module, not things a user configures. Enable or disable it via `sync_jobs` like any other job.
+The preserved set is deliberately narrow: sibling keys holding the account *name* keep syncing (they are the same on every machine), and an extension you authenticate for the first time will not be covered until its key is added — it then asks for sign-in on the target once, rather than something you wanted synced silently going stale.
+
+`~/.config/Code/machineid` is **not** carved out. pc-switcher already mirrors Settings Sync's own bookkeeping, so keeping the machine id common makes the fleet one logical Settings Sync machine, which is self-consistent; splitting it would leave two identities sharing one machine's sync state. Consequence: the Settings Sync machine list shows a single entry for the fleet.
+
+The job has no settings: the editor list, DB layout, and the preserved-key patterns are VS Code internals owned by the module, not things a user configures. Enable or disable it via `sync_jobs` like any other job.
 
 Covered VS Code-based editors: Code, Antigravity, Cursor, VSCodium. Also covered is `~/.vscode-shared/sharedStorage/state.vscdb`, an install-shared state DB outside any editor's config directory (recent VS Code versions) holding cross-install state such as the workspace-trust list and recently-opened paths; it has the same schema and is merged the same way. For each covered DB, both the main `state.vscdb` and its `state.vscdb.backup` sidecar are handled identically — the exact set `folder_sync` excludes is the exact set this job merges, so no file is hidden from the mirror without being merged. A file absent on the source is skipped. On a first sync (the target has no such DB yet) the target simply receives the secret-stripped database, causing a one-time re-login. The job runs after `folder_sync`, as the invoking normal user (no `sudo`), and needs `sqlite3` on both machines.
 

--- a/src/pcswitcher/jobs/vscode_state_sync.py
+++ b/src/pcswitcher/jobs/vscode_state_sync.py
@@ -2,10 +2,11 @@
 
 Covers VS Code and its forks (Code, Antigravity, Cursor, VSCodium — ``VSCODE_BASED_EDITORS``);
 "editor" below always means one of those, never a generic editor. Each such editor's global
-``state.vscdb`` mixes wanted global state (settings-adjacent, MRU) with machine-bound
-SecretStorage blobs under ``secret://`` keys — ciphertext encrypted with a per-machine
-OS-keyring key that is never synced. A file-granular rsync mirror would clobber the target's
-own keyring-decryptable secrets and force auth-backed extensions to re-login after every sync.
+``state.vscdb`` mixes wanted global state (settings-adjacent, MRU) with machine-bound account
+state — SecretStorage blobs under ``secret://`` keys (ciphertext encrypted with a per-machine
+OS-keyring key that is never synced) and the auth session preferences that point into them.
+A file-granular rsync mirror would clobber the target's own keyring-decryptable secrets and
+force auth-backed extensions to re-login after every sync.
 
 Alongside the per-editor DBs, the install-shared ``~/.vscode-shared/sharedStorage/state.vscdb``
 (``VSCODE_SHARED_STORAGE_DB_RELPATH``) is covered too: same schema, same handling. Whether
@@ -20,8 +21,7 @@ of THIS job, not a system-wide single-user assumption — user-data sync itself 
 users.
 
 This job (a normal-user ``SyncJob``, no sudo) rebuilds each target DB by mirroring
-every key EXCEPT ``PRESERVE_KEY_GLOBS`` matches (``secret://%``), which keep the
-target's own value:
+every key EXCEPT ``PRESERVE_KEY_GLOBS`` matches, which keep the target's own value:
 
 1. Source-strip: copy the source DB to a source-local temp, ``DELETE`` preserved
    rows -> a "neutral" DB carrying no secrets.
@@ -78,12 +78,42 @@ VSCODE_STATE_DB_RELPATHS: tuple[str, ...] = (
 )
 
 # Keys whose TARGET value is kept instead of mirrored, as SQLite LIKE patterns. Hardcoded,
-# not configurable: ``secret://`` is the VS Code SecretStorage namespace — a VS Code
-# internal on the same footing as VSCODE_BASED_EDITORS and the DB layout above. The module
-# owns every VS-Code-specific fact so the job is off-the-shelf with nothing to tune; a user
-# has no basis to widen this without knowing VS Code's key scheme, and widening it wrongly
-# would leak machine-bound secrets across the fleet.
-PRESERVE_KEY_GLOBS: tuple[str, ...] = ("secret://%",)
+# not configurable: these are VS Code internals on the same footing as VSCODE_BASED_EDITORS
+# and the DB layout above. The module owns every VS-Code-specific fact so the job is
+# off-the-shelf with nothing to tune; a user has no basis to widen this without knowing VS
+# Code's key scheme, and widening it wrongly would leak machine-bound secrets across the fleet.
+#
+# Two kinds of key are preserved, and BOTH are needed (#204):
+#
+#  * ``secret://%`` — the SecretStorage namespace, ciphertext only the local keyring decrypts.
+#  * The auth SESSION PREFERENCES that point INTO those blobs. Their value is a session id
+#    naming which session inside the secret store to use, and it is regenerated on every
+#    sign-in, so it is as machine-bound as the ciphertext it references. Preserving the blob
+#    while mirroring the pointer hands the target a session it does not have: VS Code cannot
+#    resolve an account and prompts to sign in again, which then propagates the new foreign
+#    pointer back on the next sync in the opposite direction.
+#
+# The preference patterns are anchored on the full ``<extensionId>-<providerId>`` prefix, with
+# ``%`` covering ONLY the trailing scope list — scopes are baked into the key name and change
+# when an extension requests a new one, so wildcarding just that part keeps the match exact
+# without pinning a string that rots. Deliberately NOT a broad ``%-github%``: that would also
+# preserve the sibling account-NAME keys (``vscode.github-github`` = the GitHub login), which
+# hold the same value on every machine and should keep syncing, plus any unrelated future key
+# containing ``-github-``. No ``-microsoft`` patterns: no Microsoft-provider preference key
+# was observed on any fleet machine, and speculative patterns can only over-preserve.
+#
+# Fail-open by design: a newly authenticated extension's preference key does not match and is
+# not preserved, so that extension asks for sign-in on the target once — the pre-#204
+# behaviour, no regression. Nothing that should sync stops syncing. Add a pattern when it
+# happens. NOTE ``LIKE`` treats ``_`` as a single-character wildcard; none of these contain
+# one, but an extension id that did would need ESCAPE handling.
+PRESERVE_KEY_GLOBS: tuple[str, ...] = (
+    "secret://%",
+    "userDataSyncAccountPreference",
+    "vscode.github-github-%",
+    "github.vscode-pull-request-github-github-%",
+    "github.vscode-github-actions-github-%",
+)
 
 
 # The full set of handled state-DB files: for each covered DB, the main ``state.vscdb`` and its
@@ -198,10 +228,11 @@ def target_sql_command(db_path: str, sql: str) -> str:
 class VscodeStateSyncJob(SyncJob):
     """Selective, SQLite-aware sync of VS Code editor ``state.vscdb`` (ADR-018).
 
-    Mirrors each editor's global state DB except machine-bound ``secret://`` rows
-    (``PRESERVE_KEY_GLOBS``), which keep the target's own value. Runs as the invoking
-    normal user (no sudo). The module owns every VS-Code-specific fact (editor list, DB
-    layout, preserved-key namespace), so the job takes no configuration.
+    Mirrors each editor's global state DB except machine-bound account rows
+    (``PRESERVE_KEY_GLOBS`` — ``secret://`` blobs and the auth session preferences pointing
+    into them), which keep the target's own value. Runs as the invoking normal user (no
+    sudo). The module owns every VS-Code-specific fact (editor list, DB layout,
+    preserved-key patterns), so the job takes no configuration.
     """
 
     name: ClassVar[str] = "vscode_state_sync"

--- a/tests/unit/jobs/test_vscode_state_sync.py
+++ b/tests/unit/jobs/test_vscode_state_sync.py
@@ -208,6 +208,42 @@ class TestMergeSemantics:
         assert result["vscode.auth://b"] == b"TA"
         assert result["keep"] == "src"
 
+    def test_shipped_globs_preserve_auth_pointers_and_nothing_more(self, tmp_path: Path) -> None:
+        """Regression for #204, with the real key names observed on the fleet.
+
+        The auth session preferences point INTO the preserved ``secret://`` blobs: their
+        value is a session id regenerated on every sign-in, so mirroring them hands the
+        target a session it does not hold and VS Code prompts to sign in again. Their
+        sibling account-NAME keys (same prefix, no scope suffix) and same-prefix mementos
+        must keep syncing — the globs are anchored to avoid over-preserving those.
+        """
+        preserved = [
+            "userDataSyncAccountPreference",
+            "vscode.github-github-read:user user:email repo workflow",
+            "github.vscode-pull-request-github-github-read:user user:email repo workflow",
+            "github.vscode-github-actions-github-repo workflow",
+        ]
+        mirrored = [
+            "vscode.github-github",  # account name — same on every machine
+            "github.vscode-pull-request-github-github",
+            "GitHub.vscode-pull-request-github",  # extension memento, not an auth pointer
+            "github-janfrederik-usages",
+            "settings.lastSyncUserData",
+        ]
+        source = tmp_path / "source.vscdb"
+        target = tmp_path / "target.vscdb"
+        neutral = tmp_path / "neutral.vscdb"
+        _make_db(source, [("secret://a", b"S"), *((k, "src") for k in preserved + mirrored)])
+        _make_db(target, [("secret://a", b"T"), *((k, "tgt") for k in preserved + mirrored)])
+        shutil.copyfile(source, neutral)
+        _run_script(neutral, source_strip_sql(PRESERVE_KEY_GLOBS))
+        _run_script(neutral, target_inject_sql(str(target), PRESERVE_KEY_GLOBS))
+
+        result = _read(neutral)
+        assert result["secret://a"] == b"T"
+        assert [result[k] for k in preserved] == ["tgt"] * len(preserved)
+        assert [result[k] for k in mirrored] == ["src"] * len(mirrored)
+
     def test_single_quote_in_glob_is_escaped(self, tmp_path: Path) -> None:
         """A glob containing a single quote is doubled, so the SQL runs (no injection/crash)."""
         db = tmp_path / "neutral.vscdb"
@@ -341,7 +377,7 @@ class TestExecuteOrchestration:
 
     async def test_execute_preserves_secret_keys_by_default(self, tmp_path: Path) -> None:
         """The job hardcodes secret:// preservation: no config, the inject SQL keeps those keys."""
-        assert PRESERVE_KEY_GLOBS == ("secret://%",)
+        assert PRESERVE_KEY_GLOBS[0] == "secret://%"
         home = _setup_home(tmp_path, editors=[_CODE_DB])
         ctx = _make_context(target_db_present=True)
         job = VscodeStateSyncJob(ctx)


### PR DESCRIPTION
Fixes #204.

VS Code asked for the Settings Sync sign-in again after every sync. The merge preserved the target's `secret://` blobs but mirrored the plaintext keys that name *which session inside them* to use — pointers that are as machine-bound as the ciphertext they reference.

Mechanism traced across btrfs pre-sync snapshots on both fleet machines; full evidence in #204. The short version, for `userDataSyncAccountPreference`: P17's own value was `ef24576b…`, a Fleksi→P17 sync replaced it with Fleksi's `f27aac9b…`, P17 then prompted for sign-in, and signing in produced `98023763…`. The last step was predicted before the sign-in and confirmed after it.

## Change

```python
PRESERVE_KEY_GLOBS: tuple[str, ...] = (
    "secret://%",
    "userDataSyncAccountPreference",
    "vscode.github-github-%",
    "github.vscode-pull-request-github-github-%",
    "github.vscode-github-actions-github-%",
)
```

Measured against a live `state.vscdb`: 15 → 19 preserved keys of 270, matching exactly the four intended keys and nothing else. Nothing matches in the install-shared `sharedStorage/state.vscdb`.

Each pattern is anchored on the full `<extensionId>-<providerId>` prefix, with `%` covering only the trailing scope list — scopes are baked into the key name and shift when an extension requests a new one, so wildcarding just that part stays exact without pinning a string that rots.

Deliberately narrow, per the project rule that everything syncable should sync:

- no broad `%-github%`, which would also preserve the sibling account-name keys (`vscode.github-github` = the GitHub login, identical on every machine) and the unrelated `GitHub.vscode-pull-request-github` memento, plus any future key containing `-github-`;
- no `-microsoft` patterns — no Microsoft-provider preference key exists on either machine, and a speculative pattern can only over-preserve;
- fail-open: a newly authenticated extension's key does not match and is not preserved, so it asks for sign-in on the target once — the pre-fix behaviour, no regression.

`~/.config/Code/machineid` is intentionally left syncing. pc-switcher already mirrors Settings Sync's own bookkeeping, so a common machine id makes the fleet one logical Settings Sync machine; splitting it would leave two identities sharing one machine's sync state.

## Tests

New `test_shipped_globs_preserve_auth_pointers_and_nothing_more` drives the shipped globs through the real strip → inject sequence with the actual key names observed on the fleet, asserting the four pointers keep the target's value while the account-name keys, the memento and `settings.lastSyncUserData` take the source's. Existing test relaxed from pinning the whole tuple to pinning `secret://%` as its first entry. 708 unit tests pass; ruff and basedpyright clean.

## Open question

ADR-018 is immutable (ADR-001), and its TL;DR still describes the preserve set as "every key except machine-bound `secret://` matches", which now under-describes it. Its Consequences already anticipate that "a change in VS Code's key scheme needs a code change", so this may be within its envelope — or it may warrant a superseding ADR. Left untouched pending your call.

## Verification

Not yet verified against a real sync — the mechanism is confirmed, the fix is not. Worth doing before merge: sync between the two machines and confirm neither is asked to sign in again.
