### PR TITLE
test(console): give every captured console one styling-free home

### DIFF
--- a/docs/dev/testing-guide.md
+++ b/docs/dev/testing-guide.md
@@ -77,6 +77,17 @@ success_result, failed_result # Bare CommandResults
 
 Use `mock_job_context` rather than building a `JobContext` by hand.
 
+### Asserting On What Was Printed
+
+Build the console with `captured_console()` from `tests/unit/console_capture.py`, never `Console(file=StringIO())`:
+
+```python
+console, buffer = captured_console()          # add terminal=True for the is_terminal branches
+assert "Sync finished with failures:" in buffer.getvalue()
+```
+
+It pins width and terminal-ness, and turns styling off at the source. A hand-built console honours `FORCE_COLOR` even when it writes to a buffer, so the buffer holds `\x1b[1mSync finished…` and the assertion fails only for the developers whose environment sets it (#250). `no_color=True` is not enough — it drops colour and keeps bold.
+
 ### Mocking Patterns
 
 **Basic command mocking**:

--- a/tests/unit/cli/test_commands.py
+++ b/tests/unit/cli/test_commands.py
@@ -8,18 +8,17 @@ from __future__ import annotations
 
 import subprocess
 from datetime import UTC, datetime
-from io import StringIO
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from rich.console import Console
 from typer.testing import CliRunner
 
 from pcswitcher.cli import _async_run_sync, app, update
 from pcswitcher.config import Configuration
 from pcswitcher.models import SessionStatus, SyncAborted, SyncAbortedByUser, SyncSession
 from pcswitcher.version import Release, Version
+from tests.unit.console_capture import captured_console
 
 runner = CliRunner()
 
@@ -153,17 +152,6 @@ class TestSyncAbortedHandling:
         assert "aborted" in printed.lower()
         assert "user" not in printed.lower()
         assert "failed" not in printed.lower()
-
-
-def captured_console() -> tuple[Console, StringIO]:
-    """A real `Console` writing to a buffer: a `MagicMock` accepts any string and would
-    pass no matter how the message was built.
-
-    Width pinned so no assertion depends on the terminal running the suite, and
-    no_color/highlight off so the buffer holds the literal characters printed.
-    """
-    buffer = StringIO()
-    return Console(file=buffer, width=200, no_color=True, highlight=False), buffer
 
 
 class TestToolOutputIsNotRichMarkup:

--- a/tests/unit/cli/test_version_check.py
+++ b/tests/unit/cli/test_version_check.py
@@ -12,7 +12,6 @@ process and silently kills the run.
 
 from __future__ import annotations
 
-import io
 import os
 import subprocess
 import sys
@@ -26,6 +25,7 @@ from typer.testing import CliRunner
 
 from pcswitcher import cli
 from pcswitcher.version import Release, Version
+from tests.unit.console_capture import captured_console
 
 runner = CliRunner()
 
@@ -54,14 +54,13 @@ def _isolate_skip_env_var() -> Generator[None]:  # pyright: ignore[reportUnusedF
 
 
 def _capture_console() -> Console:
-    """Build a Rich console that force-renders into an in-memory buffer.
+    """A console reporting itself as a terminal, writing into an in-memory buffer.
 
-    force_terminal ensures Rich's own markup renders, not `console.is_terminal`
-    for the TTY gate - that gate is controlled separately via
-    `patch("pcswitcher.cli.is_interactive", ...)` so tests are deterministic
-    regardless of StringIO's own terminal detection.
+    `terminal=True` covers only the code that asks `console.is_terminal`; the TTY gate is
+    controlled separately via `patch("pcswitcher.cli.is_interactive", ...)`.
     """
-    return Console(file=io.StringIO(), force_terminal=True)
+    console, _ = captured_console(terminal=True)
+    return console
 
 
 def _subprocess_side_effect(version_stdout: str) -> Callable[..., subprocess.CompletedProcess[str]]:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -8,7 +8,6 @@ Provides:
 
 from __future__ import annotations
 
-import io
 from collections.abc import Callable
 from datetime import datetime
 from typing import Any
@@ -16,13 +15,13 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from freezegun import freeze_time
-from rich.console import Console
 
 from pcswitcher.config import Configuration
 from pcswitcher.events import EventBus
 from pcswitcher.jobs import JobContext
 from pcswitcher.models import CommandResult
 from pcswitcher.orchestrator import Orchestrator
+from tests.unit.console_capture import captured_console
 
 
 @pytest.fixture
@@ -184,7 +183,7 @@ def wired_orchestrator() -> Orchestrator:
     config.btrfs_snapshots.max_age_days = 30
 
     orchestrator = Orchestrator(target="target-host", config=config)
-    orchestrator._console = Console(file=io.StringIO())  # pyright: ignore[reportPrivateUsage]
+    orchestrator._console = captured_console()[0]  # pyright: ignore[reportPrivateUsage]
     orchestrator._ui = MagicMock()  # pyright: ignore[reportPrivateUsage]
     orchestrator._logger = MagicMock()  # pyright: ignore[reportPrivateUsage]
     local_executor = MagicMock()

--- a/tests/unit/console_capture.py
+++ b/tests/unit/console_capture.py
@@ -1,0 +1,50 @@
+r"""One console for every test that asserts against what pc-switcher printed.
+
+A test that reads a buffer as plain text needs the buffer to hold plain text on every
+machine that runs it. Rich decides that from the environment: `FORCE_COLOR` (Claude Code
+and many terminals set it) makes even a `StringIO` console styled and terminal-like, so
+the same assertion passes in CI and fails on a developer's machine.
+
+`no_color=True` is not the fix -- it drops colour and keeps attributes, leaving
+`\x1b[1m...\x1b[0m` around anything bold. `color_system=None` is: Rich then renders every
+style as its text, so no escape sequence is emitted at all.
+"""
+
+from __future__ import annotations
+
+import io
+
+from rich.console import Console
+
+# Escape sequences can only reach a PlainBuffer through a console this module did not
+# build, so the message points at that rather than at the assertion that tripped over it.
+_STYLED = (
+    "captured console wrote an escape sequence: build it with captured_console() "
+    "so styling cannot depend on the environment running the suite"
+)
+
+
+class PlainBuffer(io.StringIO):
+    """A buffer that refuses to hand out styled text.
+
+    Without this, styling leaking back in is only noticed by whoever happens to have
+    `FORCE_COLOR` set, and only as an assertion that says the text was never printed.
+    """
+
+    def getvalue(self) -> str:
+        printed = super().getvalue()
+        assert "\x1b" not in printed, f"{_STYLED}\nBuffer: {printed!r}"
+        return printed
+
+
+def captured_console(*, width: int = 200, terminal: bool = False) -> tuple[Console, PlainBuffer]:
+    """A real `Console` writing to a buffer: a `MagicMock` accepts any string and would
+    pass no matter how the message was built.
+
+    Width and terminal-ness are pinned so no assertion depends on the terminal running the
+    suite, and styling is off at the source so the buffer holds the literal characters
+    printed. Pass `terminal=True` for the branches that only run for a live terminal.
+    """
+    buffer = PlainBuffer()
+    console = Console(file=buffer, width=width, force_terminal=terminal, color_system=None, highlight=False)
+    return console, buffer

--- a/tests/unit/jobs/test_manual_installs_sync.py
+++ b/tests/unit/jobs/test_manual_installs_sync.py
@@ -9,7 +9,6 @@ and snippet-replay coverage that previously lived against `AptSyncJob` in
 
 from __future__ import annotations
 
-import io
 import logging
 import re
 import shlex
@@ -18,7 +17,6 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from rich.console import Console
 from rich.panel import Panel
 
 from pcswitcher.config import Configuration
@@ -37,6 +35,7 @@ from pcswitcher.jobs.packages.state import SNIPPET_REGISTRY_RELPATH
 from pcswitcher.jobs.packages.sync_core import PackageItemFailures, PackagePlan
 from pcswitcher.models import CommandResult, Host, JobSkipped, SyncAborted, ValidationError
 from pcswitcher.orchestrator import Orchestrator
+from tests.unit.console_capture import captured_console
 
 # -- Real `apt-cache policy` output, verbatim ------------------------------------------
 #
@@ -2621,9 +2620,9 @@ class TestSnippetRegistryOverwriteGuard:
 
         message = str(confirmer.calls[0]["message"])
         # Rendered the way the real confirmer renders it: unescaped markup raises here.
-        console = Console(file=io.StringIO(), width=200, force_terminal=False, no_color=True)
+        console, buffer = captured_console()
         console.print(Panel(message))
-        rendered = console.file.getvalue()  # pyright: ignore[reportAttributeAccessIssue]
+        rendered = buffer.getvalue()
         assert "[bold]tool (unowned in /opt)" in rendered
         assert "--mode=[red]fast" in rendered
 

--- a/tests/unit/jobs/test_package_review.py
+++ b/tests/unit/jobs/test_package_review.py
@@ -9,7 +9,6 @@ answers become.
 from __future__ import annotations
 
 import asyncio
-import io
 import json
 import subprocess
 import sys
@@ -48,6 +47,7 @@ from pcswitcher.jobs.packages.review import (
 from pcswitcher.jobs.packages.sync_core import PackagePlan
 from pcswitcher.models import CommandResult, SyncAbortedByUser
 from pcswitcher.orchestrator import Orchestrator
+from tests.unit.console_capture import captured_console
 
 
 class _Hosts(TypedDict):
@@ -71,11 +71,13 @@ def _mock_isatty(interactive: bool) -> MagicMock:
 
 def _interactive_console() -> Console:
     """A Console that reports itself as a terminal (paired with a mocked isatty stdin)."""
-    return Console(file=io.StringIO(), force_terminal=True)
+    console, _ = captured_console(terminal=True)
+    return console
 
 
 def _non_interactive_console() -> Console:
-    return Console(file=io.StringIO())
+    console, _ = captured_console()
+    return console
 
 
 def _entry(item_id: str, label: str = "pkg", action_label: str = "install") -> ReviewEntry:
@@ -146,8 +148,7 @@ class TestNonInteractive:
 
     async def test_warns_naming_every_item_and_reports_groups(self) -> None:
         """H161 — `PKG-FR-LOG-DECISIONS`: a count says which items were declined to nobody."""
-        buffer = io.StringIO()
-        console = Console(file=buffer)
+        console, buffer = captured_console()
         ui = MagicMock()
         groups = [
             ReviewGroup(manager="apt", action="install", title="Install packages", entries=[_entry("a"), _entry("b")])
@@ -165,8 +166,7 @@ class TestNonInteractive:
 
     async def test_the_report_panel_ends_on_its_last_item(self) -> None:
         """A newline after the last entry renders as an empty final line inside the border."""
-        buffer = io.StringIO()
-        console = Console(file=buffer, no_color=True, width=60)
+        console, buffer = captured_console(width=60)
         groups = [
             ReviewGroup(manager="apt", action="install", title="Install packages", entries=[_entry("a"), _entry("b")])
         ]
@@ -182,8 +182,7 @@ class TestNonInteractive:
         """#226 — nothing acts on a reported condition, so the line carries no verb, and the
         version its label repeats is the one the finding attributes to each machine.
         """
-        out = io.StringIO()
-        console = Console(file=out, no_color=True, width=100)
+        console, out = captured_console(width=100)
         group = ReviewGroup(
             manager="apt",
             action="report_only",
@@ -208,8 +207,7 @@ class TestNonInteractive:
         """#226 changed the REPORT lines only: the report path a non-interactive run prints
         for a group that WOULD have acted still names the verb and the whole label.
         """
-        out = io.StringIO()
-        console = Console(file=out, no_color=True, width=100)
+        console, out = captured_console(width=100)
         group = ReviewGroup(
             manager="apt",
             action="install",
@@ -275,8 +273,7 @@ class TestInteractive:
 
     async def test_an_interactive_group_prints_no_panel_above_its_screen(self) -> None:
         """The screen lists the items itself; a panel above it said everything twice."""
-        buffer = io.StringIO()
-        console = Console(file=buffer, force_terminal=True, no_color=True, width=200)
+        console, buffer = captured_console(terminal=True)
         ui = MagicMock()
         groups = [
             ReviewGroup(
@@ -569,8 +566,7 @@ class TestInteractive:
         machine and recorded nothing, so the condition came back next sync whichever was
         chosen. A report is printed and the review moves on.
         """
-        out = io.StringIO()
-        console = Console(file=out, force_terminal=True)
+        console, out = captured_console(terminal=True)
         ui = MagicMock()
         group = ReviewGroup(
             manager="apt",
@@ -721,8 +717,7 @@ class TestAskGate:
         """T-02-02: a bracketed token in the body must reach the console verbatim rather
         than being parsed as a Rich style.
         """
-        buffer = io.StringIO()
-        console = Console(file=buffer, force_terminal=True, width=200)
+        console, buffer = captured_console(terminal=True)
         with (
             patch.object(sys, "stdin", _mock_isatty(True)),
             patch(
@@ -965,8 +960,7 @@ class TestUnreproducibleGroupResolution:
         header on prompt_toolkit's final `is_done` render, and everything printed to the
         console around the editor (its scrollback).
         """
-        sink = io.StringIO()
-        console = Console(file=sink, force_terminal=True, no_color=True, width=200)
+        console, sink = captured_console(terminal=True)
         group = _unreproducible_group([_entry("u1", label="brscan3")])
         screen = _fake_prompt(ask_return={"u1": "add_snippet"})
         text_prompt = _fake_prompt(ask_return="sudo dpkg --install /tmp/x.deb")
@@ -1515,8 +1509,7 @@ class TestRepoConflictGroupResolution:
         """C29, H94 — The user's own words: a diff of two repository definitions is not readable. The
         target's current file comes first, then the source's, each whole.
         """
-        out = io.StringIO()
-        console = Console(file=out, force_terminal=True, no_color=True, width=200)
+        console, out = captured_console(terminal=True)
         ui = MagicMock()
         entry = _conflict_entry(
             target_version="deb https://old.example.com stable main\n",
@@ -1541,8 +1534,7 @@ class TestRepoConflictGroupResolution:
         two machines' own names, and the target's says "now" because it is the one an
         overwrite would replace.
         """
-        out = io.StringIO()
-        console = Console(file=out, force_terminal=True, no_color=True, width=200)
+        console, out = captured_console(terminal=True)
         ui = MagicMock()
         screen = _fake_prompt(ask_return={"apt:conflict:vendor.list": "skip_once"})
 
@@ -1562,8 +1554,7 @@ class TestRepoConflictGroupResolution:
         """A file body's own trailing newline renders as an empty last line inside the
         panel border — every other panel in the review had the same trailing gap.
         """
-        out = io.StringIO()
-        console = Console(file=out, force_terminal=True, no_color=True, width=60)
+        console, out = captured_console(terminal=True, width=60)
         ui = MagicMock()
         entry = _conflict_entry(target_version="deb https://old.example.com stable main\n", source_version="x\n")
         screen = _fake_prompt(ask_return={"apt:conflict:vendor.list": "skip_once"})
@@ -1860,25 +1851,25 @@ class TestRemovalGroupContent:
     """A deletion screen shows the file it offers to delete, not only its name."""
 
     @staticmethod
-    def _run(group: ReviewGroup, out: io.StringIO) -> Any:
-        console = Console(file=out, force_terminal=True, no_color=True, width=200)
+    def _run(group: ReviewGroup) -> Any:
+        console, out = captured_console(terminal=True)
         screen = _fake_prompt(ask_return={entry.item_id: "skip_once" for entry in group.entries})
         return (
             patch.object(sys, "stdin", _mock_isatty(True)),
             patch("pcswitcher.jobs.packages.review.decision_list", return_value=screen),
             console,
+            out,
         )
 
     async def test_a_pin_file_is_printed_whole_under_the_machine_that_holds_it(self) -> None:
         """H37, H66 — a pin offered for deletion is printed whole, titled with the machine that holds it."""
-        out = io.StringIO()
         entry = ReviewEntry(
             item_id="apt:pin:99-vendor.pref",
             label="99-vendor.pref",
             action_label="delete pin file",
             content="Package: *\nPin: origin vendor.example.com\nPin-Priority: 900\n",
         )
-        isatty, screen, console = self._run(_pin_removal_group([entry]), out)
+        isatty, screen, console, out = self._run(_pin_removal_group([entry]))
 
         with isatty, screen:
             await review_items([_pin_removal_group([entry])], console=console, ui=MagicMock(), **HOSTS)
@@ -1892,10 +1883,9 @@ class TestRemovalGroupContent:
     async def test_an_entry_with_no_content_prints_no_panel(self) -> None:
         """A repository deletion carries its URLs in the detail line, so the screen it shares
         with the pin files must not grow an empty block for it."""
-        out = io.StringIO()
         entry = ReviewEntry(item_id="apt:source:vendor.list", label="vendor.list (list)", action_label="delete")
         group = _pin_removal_group([entry])
-        isatty, screen, console = self._run(group, out)
+        isatty, screen, console, out = self._run(group)
 
         with isatty, screen:
             await review_items([group], console=console, ui=MagicMock(), **HOSTS)
@@ -1905,7 +1895,6 @@ class TestRemovalGroupContent:
         assert "╭" not in out.getvalue()
 
     async def test_a_bracketed_pin_body_renders_without_markup_error(self) -> None:
-        out = io.StringIO()
         entry = ReviewEntry(
             item_id="apt:pin:99-vendor.pref",
             label="99-vendor.pref",
@@ -1913,7 +1902,7 @@ class TestRemovalGroupContent:
             content="Package: [bold red]not-markup[/]\n",
         )
         group = _pin_removal_group([entry])
-        isatty, screen, console = self._run(group, out)
+        isatty, screen, console, out = self._run(group)
 
         with isatty, screen:
             await review_items([group], console=console, ui=MagicMock(), **HOSTS)
@@ -1925,8 +1914,7 @@ class TestRemovalGroupContent:
         collateral one, so Ctrl-C here must end the sync and name the file rather than be
         read as declining this one deletion and moving on to the next file.
         """
-        out = io.StringIO()
-        console = Console(file=out, force_terminal=True, no_color=True, width=200)
+        console, out = captured_console(terminal=True)
         group = _pin_removal_group(
             [
                 ReviewEntry(
@@ -1969,8 +1957,7 @@ class TestCredentialsInPrintedFileBodies:
 
     @staticmethod
     async def _printed(group: ReviewGroup) -> str:
-        out = io.StringIO()
-        console = Console(file=out, force_terminal=True, no_color=True, width=200)
+        console, out = captured_console(terminal=True)
         screen = _fake_prompt(ask_return={entry.item_id: "skip_once" for entry in group.entries})
 
         with (
@@ -2019,8 +2006,7 @@ class TestCredentialsInAReviewLine:
 
     @staticmethod
     async def _printed(group: ReviewGroup) -> str:
-        out = io.StringIO()
-        console = Console(file=out, no_color=True, width=200)
+        console, out = captured_console(width=200)
 
         with (
             patch.object(sys, "stdin", _mock_isatty(False)),
@@ -2071,8 +2057,7 @@ class TestCollateralPromptWording:
 
     @staticmethod
     async def _titles(selected: str = "skip_once") -> tuple[MagicMock, str]:
-        out = io.StringIO()
-        console = Console(file=out, force_terminal=True, no_color=True, width=200)
+        console, out = captured_console(terminal=True)
         group = _collateral_group(
             [
                 ReviewEntry(

--- a/tests/unit/jobs/test_package_sync_core.py
+++ b/tests/unit/jobs/test_package_sync_core.py
@@ -11,7 +11,6 @@ reasons that have nothing to do with the shared pipeline.
 
 from __future__ import annotations
 
-import io
 import sys
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -19,7 +18,6 @@ from typing import Any, ClassVar
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from rich.console import Console
 
 from pcswitcher.events import ProgressEvent
 from pcswitcher.jobs.base import SyncJob
@@ -38,6 +36,7 @@ from pcswitcher.jobs.packages.sync_core import (  # pyright: ignore[reportPrivat
 )
 from pcswitcher.models import CommandResult, JobSkipped, JobStatus, LogLevel, SyncAbortedByUser, ValidationError
 from pcswitcher.orchestrator import Orchestrator
+from tests.unit.console_capture import captured_console
 
 
 def make_context(
@@ -805,7 +804,7 @@ class TestNoWorkBetweenTheQuestionsOfOneRound:
     @pytest.mark.asyncio
     async def test_no_executor_command_is_issued_between_the_screens_of_one_round(self) -> None:
         """H35."""
-        console = Console(file=io.StringIO(), force_terminal=True)
+        console, _ = captured_console(terminal=True)
         reviewer = TerminalUIReviewer(console, MagicMock(), source_hostname="atlas", target_hostname="nomad")
         context = make_context(reviewer=reviewer)
         job = _ThreeScreenJob(context)

--- a/tests/unit/jobs/test_review_skip_always.py
+++ b/tests/unit/jobs/test_review_skip_always.py
@@ -8,7 +8,6 @@ what the screen calls it, and what answering it produces.
 
 from __future__ import annotations
 
-import io
 import sys
 from collections.abc import Sequence
 from typing import Any, TypedDict
@@ -28,6 +27,7 @@ from pcswitcher.jobs.packages.review import (
     review_items,
 )
 from pcswitcher.models import SyncAbortedByUser
+from tests.unit.console_capture import captured_console
 
 
 class _Hosts(TypedDict):
@@ -49,7 +49,8 @@ def _mock_isatty(interactive: bool) -> MagicMock:
 
 
 def _interactive_console() -> Console:
-    return Console(file=io.StringIO(), force_terminal=True)
+    console, _ = captured_console(terminal=True)
+    return console
 
 
 def _entry(item_id: str, label: str = "pkg", action_label: str = "install") -> ReviewEntry:
@@ -246,7 +247,7 @@ class TestGroupsNeverOfferedPermanence:
 
     async def test_non_interactive_run_prompts_nothing(self) -> None:
         """H135, H160 — D-26: no TTY -> no screen at all, everything skip-once, nothing permanent."""
-        console = Console(file=io.StringIO())
+        console, _ = captured_console()
         ui = MagicMock()
         group = _group("install", [_entry("a"), _entry("b")])
 

--- a/tests/unit/test_console_capture.py
+++ b/tests/unit/test_console_capture.py
@@ -1,0 +1,61 @@
+"""#250 — a captured console prints plain text on every machine that runs the suite.
+
+Every test that reads a buffer as text rests on this. Without these, a console that starts
+honouring the environment again only fails for the developers whose environment sets
+`FORCE_COLOR`, and only as an assertion claiming the text was never printed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.unit.console_capture import PlainBuffer, captured_console
+
+
+class TestStylingCannotComeFromTheEnvironment:
+    @pytest.mark.parametrize("force_color", ["1", "3", "true"])
+    def test_a_styled_message_reaches_the_buffer_as_its_characters(
+        self, force_color: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Rich reads `FORCE_COLOR` when the console is built, so it is set first."""
+        monkeypatch.setenv("FORCE_COLOR", force_color)
+        console, buffer = captured_console()
+
+        console.print("[bold]Sync finished with failures:[/bold] [dim]apt_sync[/dim]")
+
+        assert buffer.getvalue() == "Sync finished with failures: apt_sync\n"
+
+    def test_a_terminal_console_is_styled_no_more_than_the_others(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """`terminal=True` buys the is_terminal branches, not escape sequences."""
+        monkeypatch.setenv("FORCE_COLOR", "3")
+        console, buffer = captured_console(terminal=True)
+
+        console.print("[bold]Install packages[/bold]")
+
+        assert console.is_terminal is True
+        assert buffer.getvalue() == "Install packages\n"
+
+    def test_a_console_the_environment_still_reaches_is_reported_as_that(self) -> None:
+        """The guard names the cause; an assertion on the message alone would report only
+        that some expected text was missing."""
+        buffer = PlainBuffer()
+        buffer.write("\x1b[1mSync finished with failures:\x1b[0m")
+
+        with pytest.raises(AssertionError, match="captured_console"):
+            _ = buffer.getvalue()
+
+
+class TestNothingDependsOnTheTerminalRunningTheSuite:
+    def test_width_is_pinned_against_the_environments_columns(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("COLUMNS", "37")
+        console, _ = captured_console(width=100)
+
+        assert console.width == 100
+
+    def test_a_captured_console_is_not_a_terminal_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """`FORCE_COLOR` makes Rich call even a `StringIO` console a terminal, which would
+        send the interactive branches down a path CI never takes."""
+        monkeypatch.setenv("FORCE_COLOR", "3")
+        console, _ = captured_console()
+
+        assert console.is_terminal is False

--- a/tests/unit/test_machine_naming.py
+++ b/tests/unit/test_machine_naming.py
@@ -42,6 +42,7 @@ from pcswitcher.jobs.context import JobContext
 from pcswitcher.jobs.packages.probes import ProbeFailed, require_answer
 from pcswitcher.models import CommandResult, Host
 from pcswitcher.orchestrator import Orchestrator
+from tests.unit.console_capture import captured_console
 
 _SRC = Path(pcswitcher.__file__).parent
 
@@ -323,8 +324,7 @@ class TestConfigSyncQuestions:
     def _console() -> tuple[Console, io.StringIO]:
         """A real console, not a mock: the machine names live inside Rich panels, which a
         mock records as object addresses."""
-        sink = io.StringIO()
-        return Console(file=sink, width=200, no_color=True, legacy_windows=False), sink
+        return captured_console()
 
     def test_new_config_question_names_both_machines(self) -> None:
         """H77."""


### PR DESCRIPTION
Fixes #250

## What

`captured_console()` (`tests/unit/console_capture.py`) is now the only way the unit suite builds a console that writes to a buffer. It pins width, terminal-ness and `color_system=None`, so no escape sequence is emitted whatever the environment says.

`no_color=True` was not enough: it drops colour and keeps attributes, so `\x1b[1m…\x1b[0m` survived it. That is why three tests failed for anyone whose environment sets `FORCE_COLOR` (Claude Code does) and passed in CI.

## Regression guard

- `PlainBuffer.getvalue()` raises if the buffer ever holds an escape, naming the cause instead of leaving an assertion to report text that "was never printed".
- `tests/unit/test_console_capture.py` sets `FORCE_COLOR` itself, so the guarantee is tested on machines that do not set it.

## Scope

Test-only; no product behaviour changed. The issue named `test_commands.py` and `test_package_review.py`; the same hand-built console lived in six more files, and all of them now go through the helper — that was the point of the issue ("this assumption has one home").

## Verified

- `tests/unit tests/contract`: 4630 passed with `FORCE_COLOR=3` **and** with it unset (before: 3 failures under `FORCE_COLOR=3`), and under random ordering.
- ruff check/format, codespell, basedpyright clean.

## Base

Targets `pc-216`, not `main` — `tests/unit/jobs/test_package_review.py` only exists there. Per repo history, integration CI only triggers on PRs based on `main`, so it will not run here; the change is test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqnbE49Dsf8ZgsKhh2EoHu
