### PR TITLE
docs(quick-260720-vhr): finalize bookkeeping for #195 vscode_state_sync

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -6,9 +6,9 @@ current_phase: 2
 current_phase_name: Package Management Sync
 status: executing
 stopped_at: Completed 01-18-PLAN.md
-last_updated: "2026-07-13T12:19:36.228Z"
-last_activity: 2026-07-19
-last_activity_desc: "Completed quick task 260719-g13: Check for new versions at startup (#176)"
+last_updated: "2026-07-21T13:26:41.000Z"
+last_activity: 2026-07-21
+last_activity_desc: "Finalized quick task 260720-vhr: Selective SQLite-aware sync of VS Code state.vscdb (#195)"
 progress:
   total_phases: 7
   completed_phases: 1
@@ -132,7 +132,7 @@ None yet.
 |---|-------------|------|--------|--------|-----------|
 | 260718-np8 | folder_sync include-override filter rules (#166) | 2026-07-18 | 2a2c003 | Verified | [260718-np8-folder-sync-include-override-filter-rule](./quick/260718-np8-folder-sync-include-override-filter-rule/) |
 | 260719-g13 | Check for new versions at startup (#176) | 2026-07-19 | cd765bf | Verified | [260719-g13-check-for-new-versions-at-startup-176](./quick/260719-g13-check-for-new-versions-at-startup-176/) |
-| 260720-vhr | Selective SQLite-aware sync of VS Code state.vscdb (#195) | 2026-07-20 | ed7751b | Verified | [260720-vhr-fix-195-selective-sqlite-aware-sync-of-v](./quick/260720-vhr-fix-195-selective-sqlite-aware-sync-of-v/) |
+| 260720-vhr | Selective SQLite-aware sync of VS Code state.vscdb (#195) | 2026-07-20 | d9c6478 | Verified | [260720-vhr-fix-195-selective-sqlite-aware-sync-of-v](./quick/260720-vhr-fix-195-selective-sqlite-aware-sync-of-v/) |
 
 ## Deferred Items
 

--- a/.planning/quick/260720-vhr-fix-195-selective-sqlite-aware-sync-of-v/SUMMARY.md
+++ b/.planning/quick/260720-vhr-fix-195-selective-sqlite-aware-sync-of-v/SUMMARY.md
@@ -9,7 +9,7 @@ pr: 196
 
 # SUMMARY — Fix #195: Selective SQLite-aware sync of VS Code `state.vscdb`
 
-New toggleable `vscode_state_sync` `SyncJob` (default on, runs after `folder_sync`) that mirrors each editor's global `state.vscdb` except machine-bound `secret://` keys, which keep the target's own keyring-decryptable value — so auth-backed extensions no longer re-login after every sync. `folder_sync` hardcode-excludes the editor DBs (owned constant, one-way import) so the file-granular mirror never clobbers them. Covers Code, Antigravity, Cursor, VSCodium. Preserve pattern is configurable (`preserve_key_globs`, default `["secret://%"]`). Runs as the normal user (no sudo): source-strip → SFTP transfer → target `ATTACH`+`INSERT` → atomic `mv`. Documented as ADR-018 (amends ADR-017's "only hardcoded exclude" claim).
+New toggleable `vscode_state_sync` `SyncJob` (default on, runs after `folder_sync`) that mirrors each editor's global `state.vscdb` except machine-bound `secret://` keys, which keep the target's own keyring-decryptable value — so auth-backed extensions no longer re-login after every sync. `vscode_state_sync` owns which absolute paths are the editor DBs and exposes them via `vscode_state_exclude_paths()`; `folder_sync` imports it one-way and only translates each into an rsync filter, holding no VS Code/home knowledge of its own. Covers Code, Antigravity, Cursor, VSCodium — and, per file, both `state.vscdb` and its `.backup` sidecar (exclude set == merge set, one `VSCODE_STATE_HANDLED_RELPATHS` tuple). The preserved-key pattern (`secret://%`, VS Code's SecretStorage namespace) is hardcoded in the module (`PRESERVE_KEY_GLOBS`), not user-configurable: the module owns every VS-Code-specific fact (editor list, DB layout, preserved keys), so the job is off-the-shelf with no config. Runs as the normal user (no sudo): source-strip → SFTP transfer → target `ATTACH`+`INSERT` → atomic `mv`. Documented as ADR-018 (amends ADR-017's "only hardcoded exclude" claim); the same-uid/same-path fleet assumption it relies on is ADR-019.
 
 ## Commits
 
@@ -20,10 +20,29 @@ New toggleable `vscode_state_sync` `SyncJob` (default on, runs after `folder_syn
 | `3482f7d` | feat(config): enable vscode_state_sync by default with preserve_key_globs |
 | `0fbdbcd` | docs(vscode_state_sync): ADR-018, config + step-count reconciliation |
 | `ed7751b` | fix(vscode_state_sync): mkdir -p target dir before SFTP put |
+| `fcf09ed` | docs(planning): quick-task artifacts for #195 vscode_state_sync |
+| `f26ec60` | refactor(vscode_state_sync): own exclude paths via function; folder_sync just translates |
+| `3390616` | fix(vscode_state_sync): merge state.vscdb.backup too — exclude set == merge set |
+| `69b7c42` | docs(readme): simplify user-facing prose to concise phrasing |
+| `9469b3c` | refactor(vscode_state_sync): Path-typed exclude paths; ADR-018 and wording cleanup |
+| `7fb4e8a` | docs(debug): VS Code state-loss-on-sync bug analysis |
+| `0a87e3e` | remove false negative consequence |
+| `e23583b` | docs(adr): ADR-019 homogeneous fleet — matching real users and paths |
+| `c38aece` | refactor(vscode_state_sync): drop _resolve_homes user-mapping; rename to VS Code terms |
+| `241cce8` | docs: use VS Code terminology for the state.vscdb selective sync |
+| `d9c6478` | refactor(vscode_state_sync): hardcode preserved-key pattern, drop config |
+
+## Follow-up refinements (post initial delivery)
+
+The task grew past its first five commits with structural and correctness refinements:
+- `folder_sync` no longer hardcodes the DB paths; `vscode_state_sync` owns them and exposes `vscode_state_exclude_paths()`, imported one-way — folder_sync just translates to filters (`f26ec60`, `9469b3c`).
+- The `.backup` sidecar is merged too, not only excluded, so the exclude set and merge set are identical (`3390616`).
+- Dropped the `_resolve_homes` user/path mapping in favour of the same-uid/same-path fleet assumption, captured as ADR-019; terminology narrowed to "VS Code-based editors" throughout (`e23583b`, `c38aece`, `241cce8`).
+- Preserved-key pattern made non-configurable — hardcoded `PRESERVE_KEY_GLOBS`, dropping the job's `CONFIG_SCHEMA` and the `vscode_state_sync` config section; consistent with the already-hardcoded editor list and DB layout (`d9c6478`).
 
 ## Verification
 
-Full gate green: `ruff format --check`, `ruff check`, `basedpyright` (0/0/0), `codespell`, `pytest tests/unit tests/contract` → 654 passed (+30 new). PR #196 (draft, base `main`) checks green: Lint, Unit Tests, CI Status pass; Integration correctly skipping on draft.
+Full gate green: `ruff format --check`, `ruff check`, `basedpyright` (0/0/0), `pytest tests/unit tests/contract` → 656 passed. PR #196 (draft, base `main`).
 
 ## Deferred
 


### PR DESCRIPTION
Recovers the one commit stranded on `195-selective-vscode-db-sync` after PR #196 merged: the quick-task record was finalized after the merge and never made it to `main`.

Docs only — `.planning/STATE.md` and the quick-task `SUMMARY.md`. No code.

Cherry-picked from 3a5b454a; that branch is now deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJcFbXT2hELF1WZ7vcTdXk