### PR TITLE
docs(config): the no-empty-section rule states itself instead of citing a decision id

### DIFF
--- a/docs/system/core.md
+++ b/docs/system/core.md
@@ -114,7 +114,7 @@ Lineage: 001-US-6
 
 **Example Configuration**: `pcswitcher/default-config.yaml` is the shipped, fully commented example; `pc-switcher init` writes it verbatim to `~/.config/pc-switcher/config.yaml` together with the `home.filter` and `root.filter` starter files it references.
 
-**Configuration Schema**: `src/pcswitcher/schemas/config-schema.yaml`. Job-specific settings are top-level keys outside `sync_jobs` (`btrfs_snapshots`, `disk_space_monitor`, `folder_sync`, `dummy_success`, `dummy_fail`). The five package jobs and `vscode_state_sync` have no config section — they are enabled through `sync_jobs` alone.
+**Configuration Schema**: `src/pcswitcher/schemas/config-schema.yaml`. Job-specific settings are top-level keys outside `sync_jobs` (`btrfs_snapshots`, `disk_space_monitor`, `folder_sync`, `dummy_success`, `dummy_fail`). The seven package jobs and `vscode_state_sync` have no config section — a job earns one only once it has a real key, so these are enabled through `sync_jobs` alone.
 
 ### Installation and Setup Infrastructure (CORE-US-INSTALL)
 

--- a/src/pcswitcher/jobs/manual_deb_sync.py
+++ b/src/pcswitcher/jobs/manual_deb_sync.py
@@ -59,8 +59,8 @@ class ManualDebSyncJob(UnreproducibleSyncJob):
     manager_id: ClassVar[str] = "manual_deb"
 
     # No configurable properties: mirrors AptSyncJob's empty schema — only the enable flag
-    # in sync_jobs is needed. D-32 forbids an empty placeholder config SECTION, so there is
-    # no `manual_deb_sync:` block in default-config.yaml, but the in-code CONFIG_SCHEMA
+    # in sync_jobs is needed. A job earns a config SECTION only when it has a real key, so
+    # there is no `manual_deb_sync:` block in default-config.yaml, but the in-code CONFIG_SCHEMA
     # ClassVar still declares the empty object every job carries.
     CONFIG_SCHEMA: ClassVar[dict[str, Any]] = {
         "type": "object",

--- a/src/pcswitcher/jobs/manual_flatpak_sync.py
+++ b/src/pcswitcher/jobs/manual_flatpak_sync.py
@@ -123,8 +123,8 @@ class ManualFlatpakSyncJob(UnreproducibleSyncJob):
     manager_id: ClassVar[str] = "manual_flatpak"
 
     # No configurable properties, mirroring the other package jobs: only the enable flag in
-    # sync_jobs is needed. D-32 forbids an empty placeholder config SECTION, so there is no
-    # `manual_flatpak_sync:` block in default-config.yaml, but the in-code CONFIG_SCHEMA
+    # sync_jobs is needed. A job earns a config SECTION only when it has a real key, so there is
+    # no `manual_flatpak_sync:` block in default-config.yaml, but the in-code CONFIG_SCHEMA
     # ClassVar still declares the empty object every job carries.
     CONFIG_SCHEMA: ClassVar[dict[str, Any]] = {
         "type": "object",

--- a/src/pcswitcher/jobs/manual_installs_sync.py
+++ b/src/pcswitcher/jobs/manual_installs_sync.py
@@ -165,8 +165,8 @@ class ManualInstallsSyncJob(UnreproducibleSyncJob):
     manager_id: ClassVar[str] = "manual"
 
     # No configurable properties: mirrors AptSyncJob's empty schema — only the enable flag
-    # in sync_jobs is needed. D-32 forbids an empty placeholder config SECTION, so there is
-    # no `manual_installs_sync:` block in default-config.yaml, but the in-code CONFIG_SCHEMA
+    # in sync_jobs is needed. A job earns a config SECTION only when it has a real key, so there
+    # is no `manual_installs_sync:` block in default-config.yaml, but the in-code CONFIG_SCHEMA
     # ClassVar still declares the empty object every job carries.
     CONFIG_SCHEMA: ClassVar[dict[str, Any]] = {
         "type": "object",

--- a/src/pcswitcher/jobs/manual_snap_sync.py
+++ b/src/pcswitcher/jobs/manual_snap_sync.py
@@ -60,8 +60,8 @@ class ManualSnapSyncJob(UnreproducibleSyncJob):
     manager_id: ClassVar[str] = "manual_snap"
 
     # No configurable properties: mirrors SnapSyncJob's empty schema — only the enable flag
-    # in sync_jobs is needed. D-32 forbids an empty placeholder config SECTION, so there is
-    # no `manual_snap_sync:` block in default-config.yaml, but the in-code CONFIG_SCHEMA
+    # in sync_jobs is needed. A job earns a config SECTION only when it has a real key, so
+    # there is no `manual_snap_sync:` block in default-config.yaml, but the in-code CONFIG_SCHEMA
     # ClassVar still declares the empty object every job carries.
     CONFIG_SCHEMA: ClassVar[dict[str, Any]] = {
         "type": "object",

--- a/src/pcswitcher/schemas/config-schema.yaml
+++ b/src/pcswitcher/schemas/config-schema.yaml
@@ -245,12 +245,12 @@ properties:
 
   # The apt_sync/snap_sync/flatpak_sync/manual_deb_sync/manual_snap_sync/
   # manual_flatpak_sync/manual_installs_sync jobs have no config section: they earn one only
-  # when they gain a real key (D-32). A config omitting them still
+  # when they gain a real key (see the section convention below). A config omitting them still
   # validates, and config.py's get_job_config returns {} for an absent section, which each
   # job's empty CONFIG_SCHEMA accepts. Enable/disable via sync_jobs only.
 
 # =============================================================================
-# DEVELOPER NOTE: Config Key Naming Convention
+# DEVELOPER NOTE: Config Key Conventions
 # =============================================================================
 # All job configuration MUST use a top-level key that exactly matches the
 # job's module name (the `name` class attribute). This ensures:
@@ -263,6 +263,12 @@ properties:
 #   - btrfs_snapshots.py (BtrfsSnapshotJob) -> btrfs_snapshots:
 #   - dummy_success (DummySuccessJob) -> dummy_success:
 #   - user_data.py (UserDataJob) -> user_data:
+#
+# A job earns a top-level SECTION only once it has a real key — never an empty
+# placeholder for a possible future one, and never a section that only carries a
+# banner comment. A job with no keys is enabled through `sync_jobs` alone; its
+# absent section resolves to {} in Configuration.get_job_config, which the empty
+# CONFIG_SCHEMA every such job declares accepts.
 #
 # Future job configs will be added here as top-level keys when features are implemented:
 # user_data:

--- a/tests/unit/orchestrator/test_config_system.py
+++ b/tests/unit/orchestrator/test_config_system.py
@@ -859,9 +859,9 @@ class TestShippedDefaultConfig:
             assert order.index(job_name) < folder_sync_index
 
     def test_shipped_config_omits_empty_package_sections(self) -> None:
-        """K6 — D-32: no top-level section ships for any of the seven package jobs; a job
-        earns a section only when it has a real key, and its resolved config defaults to an
-        empty mapping."""
+        """K6 — no top-level section ships for any of the seven package jobs; a job earns a
+        section only when it has a real key, and its resolved config defaults to an empty
+        mapping."""
         config = Configuration.from_yaml(self._default_config_path())
         for job_name in (
             "apt_sync",
@@ -875,7 +875,7 @@ class TestShippedDefaultConfig:
             assert config.get_job_config(job_name) == {}
 
     def test_config_omitting_package_sections_validates(self, tmp_path: Path) -> None:
-        """K7 — D-32: a config that enables every package job via sync_jobs but ships no
+        """K7 — a config that enables every package job via sync_jobs but ships no
         top-level section for them still validates (root additionalProperties: false
         rejects unknown keys, but an absent section is not one), and each job's resolved
         config is an empty mapping."""


### PR DESCRIPTION
`D-32` was cited in `config-schema.yaml`, the four `manual_*` jobs and `test_config_system.py`, but resolves to nothing: ADR-020 records D-01–D-30 and D-34–D-43. D-31/D-32/D-33 are the "Code and documentation layout" trio from `.planning/phases/02-package-management-sync/02-CONTEXT.md` — implementation rules, not architecture, so they were never promoted to an ADR and were never renumbered into one either. Every other `D-NN` in `src/`/`tests/` does resolve to ADR-020; D-32 was the sole dangling reference.

The rule is live (docs/configuration.md states it, K6/K7 enforce it), so it gets a durable home in the `config-schema.yaml` DEVELOPER NOTE next to the key-naming convention, and the six citations state it directly instead of pointing at an id.

Also: `docs/system/core.md` said five package jobs; there are seven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVVeWazT1vFWJo9NxPWKFf